### PR TITLE
fix: weChatId 유효성 따라 변경

### DIFF
--- a/src/hooks/useInitialFormikValues.ts
+++ b/src/hooks/useInitialFormikValues.ts
@@ -87,7 +87,7 @@ const useInitialFormikValues = () => {
               number: phoneNumber,
             },
             email,
-            weChatId,
+            weChatId: weChatId || null,
           },
           companyAddress: {
             postalCode: coPostalCode,


### PR DESCRIPTION
기존 weChatId가 비었을 때, "" 빈 스트링으로 서버에 전달했음
근데 이 방식이 서버 입장에서 weChatId가 필요없는 상황인지 아니면 필요한 상황인데 비었는지 알 수 없기 때문에 null을 명확히하고자 함