### PR TITLE
Info 페이지 추가 요구사항 구현 part 3 #179

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -2,7 +2,7 @@ import { AppBar, Badge, IconButton, Popover } from "@mui/material";
 import { useFormikContext } from "formik";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 
 import {
@@ -19,6 +19,7 @@ import usePageRouter, { PageName } from "@/hooks/usePageRouter";
 import useScannedItemList from "@/hooks/useScannedItemList";
 import useSelectedInfoList from "@/hooks/useSelectedInfoList";
 import { counselingIntakeFormDataState } from "@/recoil/atoms/counselingIntakeFormState";
+import { imageUrlListState } from "@/recoil/atoms/imageUrlListState";
 import { messageSnackBarState } from "@/recoil/atoms/messageSnackBarState";
 
 const StyledTitleAppBar = styled(AppBar)`
@@ -182,6 +183,7 @@ const BottomAppBar = () => {
   const setMessageSnackBarState = useSetRecoilState(messageSnackBarState);
   const { scannedItemList, setScannedItemList } = useScannedItemList();
   const { selectedInfoList, setSelectedInfoList } = useSelectedInfoList();
+  const [imageUrlList, setImageUrlList] = useRecoilState(imageUrlListState);
   const { isValid, values, resetForm, submitForm } =
     useFormikContext<FormType>();
   const setCounselingIntakeFormData = useSetRecoilState(
@@ -234,12 +236,14 @@ const BottomAppBar = () => {
           <CounselingIntakeForm
             formikValues={values}
             selectedInfoList={selectedInfoList}
+            imageUrlList={imageUrlList}
           />
         );
 
         await submitForm();
         setScannedItemList({});
         setSelectedInfoList({});
+        setImageUrlList({});
         resetForm({ values: initialValues });
         goToNextPage();
       }

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -50,7 +50,7 @@ const bottomText: PageObject = {
   qrcode: "My Products",
   cart: "Information",
   info: "Submission",
-  complete: "Scan New QR",
+  complete: "Go to Main Page",
 };
 
 const titleText: PageObject = {

--- a/src/components/CounselingIntakeForm.tsx
+++ b/src/components/CounselingIntakeForm.tsx
@@ -155,7 +155,7 @@ const CounselingIntakeForm = ({
     },
     {
       title: "Tel#",
-      value: [formikValues.phoneNumber],
+      value: [`+${formikValues.countryCode.phone} ${formikValues.phoneNumber}`],
       width: "50",
     },
     {

--- a/src/components/CounselingIntakeForm.tsx
+++ b/src/components/CounselingIntakeForm.tsx
@@ -307,7 +307,7 @@ const CounselingIntakeForm = ({
               <Text style={[styles.cell, styles.width35]}>{pid}</Text>
               <Text style={[styles.cell, styles.lastCell, styles.width50]}>
                 {Object.keys(selectedInfoList[pid]).map(
-                  (option) => `${option}: ${selectedInfoList[pid][option]}\n`
+                  (option) => `${t(option)}: ${selectedInfoList[pid][option]}\n`
                 )}
               </Text>
             </View>

--- a/src/components/CounselingIntakeForm.tsx
+++ b/src/components/CounselingIntakeForm.tsx
@@ -236,7 +236,7 @@ const CounselingIntakeForm = ({
               ))}
             </View>
             <View style={styles.table50}>
-              {clientData.map((data, idx) => (
+              {clientData.map((data) => (
                 <View key={`client-${data.title}`} style={[styles.row]}>
                   <Text
                     style={[

--- a/src/components/CounselingIntakeForm.tsx
+++ b/src/components/CounselingIntakeForm.tsx
@@ -54,7 +54,6 @@ const styles = StyleSheet.create({
   table: {
     width: "100%",
     fontSize: "10px",
-    fontWeight: "light",
   },
   table50: {
     width: "50%",
@@ -67,20 +66,26 @@ const styles = StyleSheet.create({
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
+    borderTop: "1px solid #000",
+  },
+  lastRow: {
     borderBottom: "1px solid #000",
   },
-  col: {
+  cell: {
     borderLeft: "1px solid #000",
     paddingLeft: "5px",
   },
-  width20: {
-    width: "20%",
+  lastCell: {
+    borderRight: "1px solid #000",
   },
-  width25: {
-    width: "25%",
+  image: {
+    padding: "0",
   },
-  width40: {
-    width: "40%",
+  width15: {
+    width: "15%",
+  },
+  width35: {
+    width: "35%",
   },
   width50: {
     width: "50%",
@@ -174,18 +179,32 @@ const CounselingIntakeForm = ({
     <Document>
       <Page>
         <View style={styles.table}>
-          <View style={[styles.row, styles.bold, styles.header]}>
+          <View
+            style={[
+              styles.row,
+              styles.bold,
+              styles.header,
+              styles.cell,
+              styles.lastCell,
+            ]}
+          >
             <Text>CounSeling Intake Form</Text>
             <Text>YOUNGWON</Text>
           </View>
           <View style={styles.tableBox}>
             <View style={styles.table50}>
-              {customerData.map((data) => (
-                <View key={`customer-${data.title}`} style={styles.row}>
+              {customerData.map((data, idx) => (
+                <View
+                  key={`customer-${data.title}`}
+                  style={[
+                    styles.row,
+                    idx === customerData.length - 1 ? styles.lastRow : {},
+                  ]}
+                >
                   <Text
                     style={[
                       styles.bold,
-                      styles.col,
+                      styles.cell,
                       styles[`width${data.width}`],
                     ]}
                   >
@@ -195,7 +214,7 @@ const CounselingIntakeForm = ({
                     <Text
                       key={`customer-${data.title}-value`}
                       style={[
-                        styles.col,
+                        styles.cell,
                         styles[`width${data.width}`],
                         styles[`${detectLanugage(v)}`],
                       ]}
@@ -207,13 +226,14 @@ const CounselingIntakeForm = ({
               ))}
             </View>
             <View style={styles.table50}>
-              {clientData.map((data) => (
-                <View key={`client-${data.title}`} style={styles.row}>
+              {clientData.map((data, idx) => (
+                <View key={`client-${data.title}`} style={[styles.row]}>
                   <Text
                     style={[
                       styles.bold,
-                      styles.col,
+                      styles.cell,
                       styles[`width${data.width}`],
+                      data.width === "100" ? styles.lastCell : {},
                     ]}
                   >
                     {data.title}
@@ -221,7 +241,11 @@ const CounselingIntakeForm = ({
                   {data.value.map((v) => (
                     <Text
                       key={`client-${data.title}-value`}
-                      style={[styles.col, styles[`width${data.width}`]]}
+                      style={[
+                        styles.cell,
+                        styles.lastCell,
+                        styles[`width${data.width}`],
+                      ]}
                     >
                       {v}
                     </Text>
@@ -230,36 +254,52 @@ const CounselingIntakeForm = ({
               ))}
             </View>
           </View>
-          <View style={[styles.row, styles.bold, styles.header]}>
+          <View
+            style={[
+              styles.row,
+              styles.bold,
+              styles.header,
+              styles.cell,
+              styles.lastCell,
+            ]}
+          >
             <Text>SELECTED ARTICLE LIST</Text>
           </View>
           <View style={[styles.row, styles.width100, styles.bold]}>
-            <Text style={[styles.col, styles.width20]}>ARTICLE PHOTO</Text>
-            <Text style={[styles.col, styles.width40]}>ARTICLE NO</Text>
-            <Text style={[styles.col, styles.width40]}>OPTION</Text>
+            <Text style={[styles.cell, styles.width15]}>ARTICLE PHOTO</Text>
+            <Text style={[styles.cell, styles.width35]}>ARTICLE NO</Text>
+            <Text style={[styles.cell, styles.lastCell, styles.width50]}>
+              OPTION
+            </Text>
           </View>
-          {Object.keys(selectedInfoList).map((pid) => {
-            console.log(imageUrlList[pid]);
-            return (
-              <View key={pid} style={[styles.row, styles.width100]}>
-                <Image
-                  style={[styles.col, styles.width20]}
-                  src={{
-                    uri: imageUrlList[pid],
-                    method: "GET",
-                    headers: {},
-                    body: "",
-                  }}
-                />
-                <Text style={[styles.col, styles.width40]}>{pid}</Text>
-                <Text style={[styles.col, styles.width40]}>
-                  {Object.keys(selectedInfoList[pid]).map(
-                    (option) => `${option}: ${selectedInfoList[pid][option]}\n`
-                  )}
-                </Text>
-              </View>
-            );
-          })}
+          {Object.keys(selectedInfoList).map((pid, idx) => (
+            <View
+              key={pid}
+              style={[
+                styles.row,
+                styles.width100,
+                idx === Object.keys(selectedInfoList).length - 1
+                  ? styles.lastRow
+                  : {},
+              ]}
+            >
+              <Image
+                style={[styles.cell, styles.width15, styles.image]}
+                src={{
+                  uri: imageUrlList[pid],
+                  method: "GET",
+                  headers: {},
+                  body: "",
+                }}
+              />
+              <Text style={[styles.cell, styles.width35]}>{pid}</Text>
+              <Text style={[styles.cell, styles.lastCell, styles.width50]}>
+                {Object.keys(selectedInfoList[pid]).map(
+                  (option) => `${option}: ${selectedInfoList[pid][option]}\n`
+                )}
+              </Text>
+            </View>
+          ))}
         </View>
       </Page>
     </Document>

--- a/src/components/CounselingIntakeForm.tsx
+++ b/src/components/CounselingIntakeForm.tsx
@@ -1,6 +1,7 @@
 import {
   Document,
   Font,
+  Image,
   Page,
   StyleSheet,
   Text,
@@ -10,6 +11,7 @@ import { franc } from "franc";
 
 import { FormType } from "@/components/const";
 import dayjs from "@/dayjsConfig";
+import { imageUrlList } from "@/recoil/atoms/imageUrlListState";
 import { SelectedInfoList } from "@/recoil/atoms/selectedInfoListState";
 
 const detectLanugage = (text: string) => {
@@ -69,7 +71,6 @@ const styles = StyleSheet.create({
   },
   col: {
     borderLeft: "1px solid #000",
-    borderRight: "1px solid #000",
     paddingLeft: "5px",
   },
   width20: {
@@ -127,9 +128,11 @@ const clientData = [
 const CounselingIntakeForm = ({
   formikValues,
   selectedInfoList,
+  imageUrlList,
 }: {
   formikValues: FormType;
   selectedInfoList: SelectedInfoList;
+  imageUrlList: imageUrlList;
 }) => {
   const customerData = [
     {
@@ -164,6 +167,8 @@ const CounselingIntakeForm = ({
       width: "50",
     },
   ];
+
+  console.log(imageUrlList);
 
   return (
     <Document>
@@ -233,17 +238,28 @@ const CounselingIntakeForm = ({
             <Text style={[styles.col, styles.width40]}>ARTICLE NO</Text>
             <Text style={[styles.col, styles.width40]}>OPTION</Text>
           </View>
-          {Object.keys(selectedInfoList).map((pid) => (
-            <View key={pid} style={[styles.row, styles.width100]}>
-              <Text style={[styles.col, styles.width20]}>image url</Text>
-              <Text style={[styles.col, styles.width40]}>{pid}</Text>
-              <Text style={[styles.col, styles.width40]}>
-                {Object.keys(selectedInfoList[pid]).map(
-                  (option) => `${option}: ${selectedInfoList[pid][option]}\n`
-                )}
-              </Text>
-            </View>
-          ))}
+          {Object.keys(selectedInfoList).map((pid) => {
+            console.log(imageUrlList[pid]);
+            return (
+              <View key={pid} style={[styles.row, styles.width100]}>
+                <Image
+                  style={[styles.col, styles.width20]}
+                  src={{
+                    uri: imageUrlList[pid],
+                    method: "GET",
+                    headers: {},
+                    body: "",
+                  }}
+                />
+                <Text style={[styles.col, styles.width40]}>{pid}</Text>
+                <Text style={[styles.col, styles.width40]}>
+                  {Object.keys(selectedInfoList[pid]).map(
+                    (option) => `${option}: ${selectedInfoList[pid][option]}\n`
+                  )}
+                </Text>
+              </View>
+            );
+          })}
         </View>
       </Page>
     </Document>

--- a/src/components/CounselingIntakeForm.tsx
+++ b/src/components/CounselingIntakeForm.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from "@react-pdf/renderer";
 import { franc } from "franc";
+import { useTranslation } from "react-i18next";
 
 import { FormType } from "@/components/const";
 import dayjs from "@/dayjsConfig";
@@ -16,13 +17,23 @@ import { SelectedInfoList } from "@/recoil/atoms/selectedInfoListState";
 
 const detectLanugage = (text: string) => {
   const langCode = franc(text, { minLength: 0 });
-  switch (langCode) {
-    case "cmn":
-      return "zh";
-    case "kor":
-      return "ko";
-    default:
-      return "en";
+
+  if (langCode === "cmn") {
+    return "zh";
+  } else if (langCode === "kor") {
+    return "ko";
+  } else if (langCode === "eng") {
+    return "en";
+  } else {
+    for (const c of text.split("")) {
+      const convertedCharCode = franc(c, { minLength: 0 });
+      if (convertedCharCode === "cmn") {
+        return "zh";
+      } else if (convertedCharCode === "kor") {
+        return "ko";
+      }
+    }
+    return "en";
   }
 };
 
@@ -105,31 +116,6 @@ const styles = StyleSheet.create({
   },
 });
 
-const clientData = [
-  { title: "In charge", value: ["JAY KIM"], width: "50" },
-  { title: "Contact information", value: [], width: "100" },
-  {
-    title: "Email",
-    value: ["JAY@YOUNGWONINT.COM\nYW0011S@NATE.COM"],
-    width: "50",
-  },
-  {
-    title: "Address",
-    value: ["SUITE304, 1130 DALGUBEOL-DAERO, DAEGU, SOUTH KOREA 42709"],
-    width: "50",
-  },
-  {
-    title: "Tel#",
-    value: ["+82 53 571 7676\n+82 10 3916 1371"],
-    width: "50",
-  },
-  {
-    title: "Wechat ID",
-    value: ["jayywmaeil"],
-    width: "50",
-  },
-];
-
 const CounselingIntakeForm = ({
   formikValues,
   selectedInfoList,
@@ -139,44 +125,68 @@ const CounselingIntakeForm = ({
   selectedInfoList: SelectedInfoList;
   imageUrlList: imageUrlList;
 }) => {
+  const { t, i18n } = useTranslation();
+  const clientData = [
+    { title: t("In charge"), value: ["JAY KIM"], width: "50" },
+    { title: t("Contact information"), value: [], width: "100" },
+    {
+      title: t("Email"),
+      value: ["JAY@YOUNGWONINT.COM\nYW0011S@NATE.COM"],
+      width: "50",
+    },
+    {
+      title: t("Address"),
+      value: ["SUITE304, 1130 DALGUBEOL-DAERO, DAEGU, SOUTH KOREA 42709"],
+      width: "50",
+    },
+    {
+      title: t("Tel#"),
+      value: ["+82 53 571 7676\n+82 10 3916 1371"],
+      width: "50",
+    },
+    {
+      title: "Wechat ID",
+      value: ["jayywmaeil"],
+      width: "50",
+    },
+  ];
+
   const customerData = [
     {
-      title: "Date",
+      title: t("Date"),
       value: [dayjs().format("YYYY-MM-DD")],
       width: "50",
     },
-    { title: "Company", value: [formikValues.companyName], width: "50" },
+    { title: t("Company"), value: [formikValues.companyName], width: "50" },
     {
-      title: "Customer",
+      title: t("Customer"),
       value: [formikValues.name],
       width: "50",
     },
     {
-      title: "Country",
+      title: t("Country"),
       value: [formikValues.countryCode.label],
       width: "50",
     },
     {
-      title: "Email ",
+      title: t("Email"),
       value: [formikValues.email],
       width: "50",
     },
     {
-      title: "Tel#",
+      title: t("Tel#"),
       value: [`+${formikValues.countryCode.phone} ${formikValues.phoneNumber}`],
       width: "50",
     },
     {
-      title: "Wechat ID (optional)",
+      title: `Wechat ID (${t("optional")})`,
       value: [formikValues.weChatId],
       width: "50",
     },
   ];
 
-  console.log(imageUrlList);
-
   return (
-    <Document>
+    <Document style={styles[i18n.language]}>
       <Page>
         <View style={styles.table}>
           <View
@@ -188,7 +198,7 @@ const CounselingIntakeForm = ({
               styles.lastCell,
             ]}
           >
-            <Text>CounSeling Intake Form</Text>
+            <Text>{t("Counseling Intake Form")}</Text>
             <Text>YOUNGWON</Text>
           </View>
           <View style={styles.tableBox}>
@@ -263,13 +273,15 @@ const CounselingIntakeForm = ({
               styles.lastCell,
             ]}
           >
-            <Text>SELECTED ARTICLE LIST</Text>
+            <Text>{t("SELECTED ARTICLE LIST")}</Text>
           </View>
           <View style={[styles.row, styles.width100, styles.bold]}>
-            <Text style={[styles.cell, styles.width15]}>ARTICLE PHOTO</Text>
-            <Text style={[styles.cell, styles.width35]}>ARTICLE NO</Text>
+            <Text style={[styles.cell, styles.width15]}>
+              {t("ARTICLE PHOTO")}
+            </Text>
+            <Text style={[styles.cell, styles.width35]}>{t("ARTICLE NO")}</Text>
             <Text style={[styles.cell, styles.lastCell, styles.width50]}>
-              OPTION
+              {t("OPTIONS")}
             </Text>
           </View>
           {Object.keys(selectedInfoList).map((pid, idx) => (

--- a/src/components/MessageDialog.tsx
+++ b/src/components/MessageDialog.tsx
@@ -8,9 +8,15 @@ import {
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
-const StyledMessageDialog = styled(Dialog)<{ customstyle?: string }>`
+interface StyledMessageDialogProps {
+  customStyle?: string;
+}
+
+const StyledMessageDialog = styled(Dialog).withConfig({
+  shouldForwardProp: (prop) => !["customStyle"].includes(prop),
+})<StyledMessageDialogProps>`
   p {
-    ${(props) => props.customstyle};
+    ${(props) => props.customStyle || ""};
   }
 `;
 
@@ -31,7 +37,7 @@ const MessageDialog = ({
     <StyledMessageDialog
       open={isDialogOpen}
       onClose={onDialogClose}
-      customstyle={customStyle}
+      customStyle={customStyle}
     >
       <DialogContent>
         {messageList.map((message, idx) => (

--- a/src/components/MessageDialog.tsx
+++ b/src/components/MessageDialog.tsx
@@ -16,7 +16,7 @@ const StyledMessageDialog = styled(Dialog).withConfig({
   shouldForwardProp: (prop) => !["customStyle"].includes(prop),
 })<StyledMessageDialogProps>`
   p {
-    ${(props) => props.customStyle || ""};
+    ${(props) => props.customStyle};
   }
 `;
 

--- a/src/components/MessageDialog.tsx
+++ b/src/components/MessageDialog.tsx
@@ -8,9 +8,9 @@ import {
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
-const StyledMessageDialog = styled(Dialog)<{ customStyle?: string }>`
+const StyledMessageDialog = styled(Dialog)<{ customstyle?: string }>`
   p {
-    ${(props) => props.customStyle};
+    ${(props) => props.customstyle};
   }
 `;
 
@@ -31,7 +31,7 @@ const MessageDialog = ({
     <StyledMessageDialog
       open={isDialogOpen}
       onClose={onDialogClose}
-      customStyle={customStyle}
+      customstyle={customStyle}
     >
       <DialogContent>
         {messageList.map((message, idx) => (

--- a/src/components/pages/ToBuyListPage.tsx
+++ b/src/components/pages/ToBuyListPage.tsx
@@ -1,7 +1,8 @@
 import { Box } from "@mui/material";
 import { useFormikContext } from "formik";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { styled } from "styled-components";
 
 import { EMPTY_TEXT, FormType, IS_USING_SY } from "@/components/const";
@@ -18,7 +19,7 @@ import ToBuyItemOptions from "@/components/ToBuyList/ToBuyItemOptions";
 import useScannedItemList from "@/hooks/useScannedItemList";
 import useSelectedInfoList from "@/hooks/useSelectedInfoList";
 import { fetchedItemListSelector } from "@/recoil/atoms/fetchedItemListState";
-
+import { imageUrlListState } from "@/recoil/atoms/imageUrlListState";
 
 const StyledDiv = styled.div`
   align-items: normal;
@@ -106,6 +107,35 @@ const ToBuyListPage = () => {
   const fetchedItemList = useRecoilValue(fetchedItemListSelector);
   const { scannedItemList, setScannedItemList } = useScannedItemList();
   const { selectedInfoList, setSelectedInfoList } = useSelectedInfoList();
+  const [imageUrlList, setImageUrlList] = useRecoilState(imageUrlListState);
+
+  const convertToBase64 = (url) => {
+    return new Promise((resolve, reject) => {
+      const fileReader = new FileReader();
+      fileReader.readAsDataURL(url);
+      fileReader.onload = () => {
+        resolve(fileReader.result);
+      };
+      fileReader.onerror = (error) => {
+        reject(error);
+      };
+    });
+  };
+
+  useEffect(() => {
+    fetchedItemList
+      .filter((item) =>
+        Object.keys(scannedItemList).some((pid) => pid === item.productId)
+      )
+      .map((product) => {
+        //     const base64 = convertToBase64(product.image);
+        //     console.log(base64);
+        setImageUrlList({
+          ...imageUrlList,
+          [product.productId]: product.image ? product.image : "",
+        });
+      });
+  }, [fetchedItemList, scannedItemList]);
 
   const handleToBuyItemDelete = (
     e: React.MouseEvent<HTMLElement, MouseEvent>,

--- a/src/components/pages/ToBuyListPage.tsx
+++ b/src/components/pages/ToBuyListPage.tsx
@@ -2,7 +2,7 @@ import { Box } from "@mui/material";
 import { useFormikContext } from "formik";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 
 import { EMPTY_TEXT, FormType, IS_USING_SY } from "@/components/const";
@@ -107,20 +107,7 @@ const ToBuyListPage = () => {
   const fetchedItemList = useRecoilValue(fetchedItemListSelector);
   const { scannedItemList, setScannedItemList } = useScannedItemList();
   const { selectedInfoList, setSelectedInfoList } = useSelectedInfoList();
-  const [imageUrlList, setImageUrlList] = useRecoilState(imageUrlListState);
-
-  const convertToBase64 = (url) => {
-    return new Promise((resolve, reject) => {
-      const fileReader = new FileReader();
-      fileReader.readAsDataURL(url);
-      fileReader.onload = () => {
-        resolve(fileReader.result);
-      };
-      fileReader.onerror = (error) => {
-        reject(error);
-      };
-    });
-  };
+  const setImageUrlList = useSetRecoilState(imageUrlListState);
 
   useEffect(() => {
     fetchedItemList
@@ -128,12 +115,10 @@ const ToBuyListPage = () => {
         Object.keys(scannedItemList).some((pid) => pid === item.productId)
       )
       .map((product) => {
-        //     const base64 = convertToBase64(product.image);
-        //     console.log(base64);
-        setImageUrlList({
-          ...imageUrlList,
-          [product.productId]: product.image ? product.image : "",
-        });
+        setImageUrlList((prevImageUrlList) => ({
+          ...prevImageUrlList,
+          [product.productId]: product.image || "",
+        }));
       });
   }, [fetchedItemList, scannedItemList]);
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -50,5 +50,18 @@
   "Scan New QR": "Scan New QR",
   "Result": "Result",
   "Go to Main Page": "Go to Main Page",
-  "Download Order History PDF": "Download Order History PDF"
+  "Download Order History PDF": "Download Order History PDF",
+  "Date": "Date",
+  "Company": "Company",
+  "Country": "Country",
+  "Tel#": "Tel#",
+  "optional": "optional",
+  "Customer": "Customer",
+  "In charge": "In charge",
+  "Contact information": "Contact Information",
+  "SELECTED ARTICLE LIST": "SELECTED ARTICLE LIST",
+  "ARTICLE PHOTO": "ARTICLE PHOTO",
+  "ARTICLE NO": "ARTICLE NO",
+  "OPTIONS": "OPTIONS",
+  "Counseling Intake Form": "Counseling Intake Form"
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -49,5 +49,6 @@
   "Dialog2": "After selecting the product you want, please click the shopping cart button, enter the shipping information, and finally click submit.",
   "Scan New QR": "Scan New QR",
   "Result": "Result",
+  "Go to Main Page": "Go to Main Page",
   "Download Order History PDF": "Download Order History PDF"
 }

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -50,5 +50,18 @@
   "Scan New QR": "새로운 QR 스캔하기",
   "Result": "결과",
   "Go to Main Page": "메인 페이지로 이동",
-  "Download Order History PDF": "주문 내역 PDF 다운로드"
+  "Download Order History PDF": "주문 내역 PDF 다운로드",
+  "Date": "날짜",
+  "Company": "회사",
+  "Country": "국가",
+  "Tel#": "전화번호",
+  "optional": "옵션",
+  "Customer": "고객",
+  "In charge": "책임자",
+  "Contact information": "연락처",
+  "SELECTED ARTICLE LIST": "선택한 제품 목록",
+  "ARTICLE PHOTO": "제품 사진",
+  "ARTICLE NO": "제품 번호",
+  "OPTIONS": "옵션",
+  "Counseling Intake Form": "주문 내역 확인서"
 }

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -49,5 +49,6 @@
   "Dialog2": "원하는 제품을 선택한 후 장바구니 버튼을 클릭하고 배송 정보를 입력한 후 마지막으로 제출을 클릭하세요.",
   "Scan New QR": "새로운 QR 스캔하기",
   "Result": "결과",
+  "Go to Main Page": "메인 페이지로 이동",
   "Download Order History PDF": "주문 내역 PDF 다운로드"
 }

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -49,5 +49,6 @@
   "Dialog2": "选好您想要的产品后 请按购物车按钮 输入发货信息 最后点击提交",
   "Scan New QR": "扫描新二维码",
   "Result": "结果",
+  "Go to Main Page": "转到首页",
   "Download Order History PDF": "下载订单历史 PDF"
 }

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -50,5 +50,18 @@
   "Scan New QR": "扫描新二维码",
   "Result": "结果",
   "Go to Main Page": "转到首页",
-  "Download Order History PDF": "下载订单历史 PDF"
+  "Download Order History PDF": "下载订单历史 PDF",
+  "Date": "日期",
+  "Company": "公司",
+  "Country": "国家",
+  "Tel#": "电话号码",
+  "optional": "可选的",
+  "Customer": "客户",
+  "In charge": "负责",
+  "Contact information": "联系信息",
+  "SELECTED ARTICLE LIST": "选择的产品列表",
+  "ARTICLE PHOTO": "产品照片",
+  "ARTICLE NO": "产品编号",
+  "OPTIONS": "选项",
+  "Counseling Intake Form": "咨询接纳表"
 }

--- a/src/recoil/atoms/imageUrlListState.ts
+++ b/src/recoil/atoms/imageUrlListState.ts
@@ -1,0 +1,10 @@
+import { atom } from "recoil";
+
+export interface imageUrlList {
+  [productId: string]: string;
+}
+
+export const imageUrlListState = atom<imageUrlList>({
+  key: "imageUrlListState",
+  default: {},
+});


### PR DESCRIPTION
- PDF 내부 이미지 로드 기능 구현
- PDF 스타일 수정
- PDF 내부 번역
- PDF 언어 감지 함수 로직 추가
    - 감지한 언어 코드가 "cmn", "kor", "eng" 중 하나가 아닌 경우, 즉 두 언어를 섞어 쓰는 경우 한 글자씩 언어를 감지함
        - e.g. "Wechat ID (옵션)"
    - 한국어가 있는 경우 한국어 폰트, 중국어가 있는 경우 중국어 폰트를 적용하도록 함
    - 영어와 다른 언어를 섞어 쓸 때를 대비한 것으로 한국어, 중국어를 섞어 쓰는 경우는 처리하지 않음

### 언어를 한국어로 설정했을 때
<img width="788" alt="스크린샷 2024-07-28 오후 3 45 46" src="https://github.com/user-attachments/assets/0fd86369-c2f2-45e3-937e-069a0432dd7a">

### 언어를 중국어로 설정했을 때
<img width="786" alt="스크린샷 2024-07-28 오후 3 47 08" src="https://github.com/user-attachments/assets/d78658b0-a010-4c54-872c-8088448e5b60">

### 언어를 영어로 설정했을 때
<img width="786" alt="스크린샷 2024-07-28 오후 3 47 52" src="https://github.com/user-attachments/assets/f2d3f663-5601-4656-911b-56842df4d93c">
