### PR TITLE
이미지 없을 시 대응 컴포넌트 구현

### DIFF
--- a/src/components/ImageWithFallback.tsx
+++ b/src/components/ImageWithFallback.tsx
@@ -1,0 +1,30 @@
+import ImageNotSupportedIcon from "@mui/icons-material/ImageNotSupported";
+import Image from "next/image";
+import { useState } from "react";
+
+const ImageWithFallback = ({ width, height, src, alt, className = "" }) => {
+  const [imageError, setImageError] = useState(false);
+
+  const handleImageError = () => {
+    setImageError(true);
+  };
+
+  if (!src || imageError) {
+    return <ImageNotSupportedIcon className={className} />;
+  }
+
+  return (
+    <Image
+      className={className}
+      width={width}
+      height={height}
+      src={src}
+      loading="lazy"
+      unoptimized
+      alt={alt}
+      onError={handleImageError}
+    />
+  );
+};
+
+export default ImageWithFallback;

--- a/src/components/Manager/Product/ProductDetailModal.tsx
+++ b/src/components/Manager/Product/ProductDetailModal.tsx
@@ -2,8 +2,8 @@ import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 import { useOverlay } from "@toss/use-overlay";
-import Image from "next/image";
 
+import ImageWithFallback from "@/components/ImageWithFallback";
 import { StyledModal } from "@/components/Manager/DashboardItems";
 import { productDetailColumns } from "@/components/Manager/Product/const";
 import ProductEditModal from "@/components/Manager/Product/ProductEditModal";
@@ -27,9 +27,11 @@ const StyledDetailModalContainer = styled.div`
       .imageContainer {
         min-width: 276px;
         min-height: 276px;
-        > img {
+        > img,
+        > svg {
           min-width: 276px;
           min-height: 276px;
+          color: var(--color-gray-60);
         }
       }
       .productDetail {
@@ -85,18 +87,12 @@ const ProductDetailModal = ({
         <div className="productContainer">
           <div className="baseInfo">
             <div className="imageContainer">
-              {image ? (
-                <Image
-                  width={276}
-                  height={276}
-                  src={`${image ?? ""}`}
-                  loading="lazy"
-                  unoptimized
-                  alt={productId}
-                />
-              ) : (
-                <>no image</>
-              )}
+              <ImageWithFallback
+                width={276}
+                height={276}
+                src={image}
+                alt={productId}
+              />
             </div>
             <div className="productDetail">
               <h4>{productId}</h4>

--- a/src/components/ToBuyList/ToBuyItemMain.tsx
+++ b/src/components/ToBuyList/ToBuyItemMain.tsx
@@ -1,4 +1,3 @@
-import ImageNotSupportedIcon from "@mui/icons-material/ImageNotSupported";
 import {
   Button,
   IconButton,
@@ -6,7 +5,6 @@ import {
   Select,
   SelectChangeEvent,
 } from "@mui/material";
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 
 import { IS_USING_SY } from "@/components/const";
@@ -21,6 +19,7 @@ import {
   Counter,
   MenuItemDivider,
   SelectedOption,
+  StyledImageWithFallback,
   StyledInput,
   StyledInputLabel,
   StyledMenuItem,
@@ -110,18 +109,12 @@ const ToBuyItemMain = ({
 
   return (
     <StyledTop>
-      {image ? (
-        <Image
-          width={IMG_SIZE}
-          height={IMG_SIZE}
-          src={`${image ?? ""}`}
-          loading="lazy"
-          unoptimized
-          alt={name}
-        />
-      ) : (
-        <ImageNotSupportedIcon />
-      )}
+      <StyledImageWithFallback
+        src={image}
+        width={IMG_SIZE}
+        height={IMG_SIZE}
+        alt={name}
+      />
       <StyledRight>
         <StyledNameDiv>
           <p>{name}</p>

--- a/src/components/ToBuyList/ToBuyItemMain.tsx
+++ b/src/components/ToBuyList/ToBuyItemMain.tsx
@@ -1,3 +1,4 @@
+import ImageNotSupportedIcon from "@mui/icons-material/ImageNotSupported";
 import {
   Button,
   IconButton,
@@ -109,14 +110,18 @@ const ToBuyItemMain = ({
 
   return (
     <StyledTop>
-      <Image
-        width={IMG_SIZE}
-        height={IMG_SIZE}
-        src={`${image ?? ""}`}
-        loading="lazy"
-        unoptimized
-        alt={name}
-      />
+      {image ? (
+        <Image
+          width={IMG_SIZE}
+          height={IMG_SIZE}
+          src={`${image ?? ""}`}
+          loading="lazy"
+          unoptimized
+          alt={name}
+        />
+      ) : (
+        <ImageNotSupportedIcon />
+      )}
       <StyledRight>
         <StyledNameDiv>
           <p>{name}</p>

--- a/src/components/ToBuyList/styled.ts
+++ b/src/components/ToBuyList/styled.ts
@@ -8,6 +8,8 @@ import {
   TextField,
 } from "@mui/material";
 
+import ImageWithFallback from "@/components/ImageWithFallback";
+
 const StyledWrapper = styled.div`
   border: 0.5px solid var(--color-gray-40);
   border-radius: 12px;
@@ -38,18 +40,6 @@ const StyledTop = styled.div`
     width: 100%;
   }
 
-  & > img,
-  > svg {
-    margin-right: 20px;
-    border-radius: 2px;
-    min-height: 71px;
-    min-width: 71px;
-  }
-
-  & > svg {
-    color: var(--color-gray-60);
-  }
-
   & .MuiInputBase-root {
     color: var(--color-primary);
     font-size: 12px;
@@ -62,6 +52,14 @@ const StyledTop = styled.div`
   & .Mui-focused .MuiOutlinedInput-notchedOutline {
     border: 1px solid var(--color-text-field-primary);
   }
+`;
+
+const StyledImageWithFallback = styled(ImageWithFallback)`
+  margin-right: 20px;
+  border-radius: 2px;
+  min-height: 71px;
+  min-width: 71px;
+  color: var(--color-gray-60);
 `;
 
 const StyledRight = styled.div`
@@ -250,6 +248,7 @@ export {
   StyledBottom,
   StyledBox,
   StyledButton,
+  StyledImageWithFallback,
   StyledInput,
   StyledInputLabel,
   StyledMenuItem,

--- a/src/components/ToBuyList/styled.ts
+++ b/src/components/ToBuyList/styled.ts
@@ -38,11 +38,16 @@ const StyledTop = styled.div`
     width: 100%;
   }
 
-  & > img {
+  & > img,
+  > svg {
     margin-right: 20px;
     border-radius: 2px;
     min-height: 71px;
     min-width: 71px;
+  }
+
+  & > svg {
+    color: var(--color-gray-60);
   }
 
   & .MuiInputBase-root {


### PR DESCRIPTION
### Preview
| 매니저 | 유저 |
|---------|---------|
| <img alt="매니저" src="https://github.com/user-attachments/assets/d7e2df62-0cb9-4a73-8461-01ca31dd6d81"> | <img alt="유저" src="https://github.com/user-attachments/assets/80635f84-e944-4d55-afb4-f02ed9540be0"> |

+ 이미지가 없거나(src="") 이미지 불러오기 실패 시 ImageNotSupportedIcon 아이콘을 반환하는 컴포넌트 구현
+ 별도의 스타일링은 외부에서 처리하는 방식 (className으로 해결)
  Emotion은 styled를 통해서 자동으로 className을 생성하기 때문에 이를 아래 컴포넌트에 내려주는 것으로 스타일링 상속 문제 해결