### PR TITLE
refactor: OrdererInfo 등으로 쓰이던 user 단어 통일

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { SERVER_URL } from "@/components/const";
-import { Folder, OrdererInfo, Product } from "@/const";
+import { Folder, Product, User } from "@/const";
 import {
   transformProductForFolderUpdate,
   transformUserForUpdate,
@@ -210,14 +210,11 @@ export const permanentDeleteProductList = (
   return Promise.all(deletePromises).then(onSuccess).catch(onFail);
 };
 
-export const getOrdererInfoList: ApiGetFunction<OrdererInfo[]> = (
-  onSuccess,
-  onFail
-) => {
+export const getUserList: ApiGetFunction<User[]> = (onSuccess, onFail) => {
   return http.get(`/users`, { credentials: "include" }, onSuccess, onFail);
 };
 
-export const submitOrdererInfo: ApiModifyFunction<OrdererInfo> = (
+export const submitUser: ApiModifyFunction<User> = (
   body,
   onSuccess,
   onFail
@@ -241,7 +238,7 @@ const putUser: ApiModifyFunction<SucceedResponse> = (
 };
 
 export const editUserRemark = (
-  user: OrdererInfo,
+  user: User,
   onSuccess: SuccessCallback<SucceedResponse>,
   onFail: FailCallback
 ) => {
@@ -249,13 +246,13 @@ export const editUserRemark = (
 };
 
 export const reassignFolder = (
-  dataList: OrdererInfo[] | Product[],
+  dataList: User[] | Product[],
   folderId: string,
   onSuccess: SuccessCallback<SucceedResponse[] | Product[]>,
   onFail: FailCallback
 ) => {
   const promises: Promise<SucceedResponse | Product>[] = [];
-  dataList.forEach((d: OrdererInfo | Product) => {
+  dataList.forEach((d: User | Product) => {
     promises.push(
       new Promise((resolve, reject) => {
         "productId" in d

--- a/src/components/common/CounselingIntakeForm.tsx
+++ b/src/components/common/CounselingIntakeForm.tsx
@@ -147,13 +147,13 @@ const styles = StyleSheet.create({
 });
 
 const CounselingIntakeForm = ({
-  ordererInfo,
+  userInfo,
   selectedInfoList,
   imageUrlList,
   userId,
   language,
 }: {
-  ordererInfo: Partial<FormType>;
+  userInfo: Partial<FormType>;
   selectedInfoList: SelectedInfoList;
   imageUrlList: imageUrlList;
   userId: string;
@@ -196,32 +196,32 @@ const CounselingIntakeForm = ({
     { title: t("User ID"), value: [userId], width: "50" },
     {
       title: t("Company"),
-      value: [ordererInfo.companyName],
+      value: [userInfo.companyName],
       width: "50",
     },
     {
       title: t("Customer"),
-      value: [ordererInfo.name],
+      value: [userInfo.name],
       width: "50",
     },
     {
       title: t("Country"),
-      value: [ordererInfo.countryCode?.label],
+      value: [userInfo.countryCode?.label],
       width: "50",
     },
     {
       title: t("Email"),
-      value: [ordererInfo.email],
+      value: [userInfo.email],
       width: "50",
     },
     {
       title: t("Tel#"),
-      value: [`+${ordererInfo.countryCode?.phone} ${ordererInfo.phoneNumber}`],
+      value: [`+${userInfo.countryCode?.phone} ${userInfo.phoneNumber}`],
       width: "50",
     },
     {
       title: `Wechat ID (${t("optional")})`,
-      value: [ordererInfo.weChatId],
+      value: [userInfo.weChatId],
       width: "50",
     },
   ];

--- a/src/components/manager/folder/DataFolderReassignModal.tsx
+++ b/src/components/manager/folder/DataFolderReassignModal.tsx
@@ -12,7 +12,7 @@ import * as Yup from "yup";
 
 import { reassignFolder } from "@/api";
 import MessageDialog from "@/components/common/MessageDialog";
-import { Folder, OrdererInfo, Product } from "@/const";
+import { Folder, Product, User } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -38,7 +38,7 @@ const DataFolderReassignModal = ({
 }: {
   isModalOpen: boolean;
   onModalClose: () => void;
-  selectedDataList: OrdererInfo[] | Product[];
+  selectedDataList: User[] | Product[];
   folder: Folder;
   folderList: Folder[];
   onReassignComplete?: () => void;

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -6,8 +6,8 @@ import JSZip from "jszip";
 import { useEffect, useState } from "react";
 
 import {
-  getOrdererInfoList,
   getProductList,
+  getUserList,
   permanentDeleteOrdererList,
   reassignFolder,
 } from "@/api";
@@ -24,7 +24,7 @@ import {
   countries,
   CountryType,
 } from "@/components/user/userSubmission/countries";
-import { Folder, OrdererInfo, Product } from "@/const";
+import { Folder, Product, User } from "@/const";
 import { imageUrlList } from "@/recoil/user/atoms/imageUrlListState";
 import { SelectedInfoList } from "@/recoil/user/atoms/selectedInfoListState";
 
@@ -51,8 +51,8 @@ const UserBoard = ({
   folder: Folder;
   userFolderList: Folder[];
 }) => {
-  const [userInfoList, setUserInfoList] = useState<OrdererInfo[]>([]);
-  const filteredUserList = userInfoList.filter((u) => {
+  const [userList, setUserList] = useState<User[]>([]);
+  const filteredUserList = userList.filter((u) => {
     if (folder.id === USER_DEFAULT) {
       return u.metadata.folderId !== USER_TRASH_CAN;
     }
@@ -62,10 +62,10 @@ const UserBoard = ({
   const overlay = useOverlay();
   const [productList, setProductList] = useState<Product[]>([]);
 
-  const updateOrdererInfoList = () => {
-    getOrdererInfoList(
+  const updateUserList = () => {
+    getUserList(
       (data) => {
-        setUserInfoList(data);
+        setUserList(data);
       },
       () => {
         overlay.open(({ isOpen, close }) => (
@@ -86,7 +86,7 @@ const UserBoard = ({
       ),
       USER_DEFAULT,
       () => {
-        updateOrdererInfoList();
+        updateUserList();
       },
       () => {
         overlay.open(({ isOpen, close }) => (
@@ -107,7 +107,7 @@ const UserBoard = ({
       ),
       USER_TRASH_CAN,
       () => {
-        updateOrdererInfoList();
+        updateUserList();
       },
       () => {
         overlay.open(({ isOpen, close }) => (
@@ -125,7 +125,7 @@ const UserBoard = ({
     permanentDeleteOrdererList(
       selectedUserList,
       () => {
-        updateOrdererInfoList();
+        updateUserList();
       },
       () => {
         overlay.open(({ isOpen, close }) => (
@@ -151,7 +151,7 @@ const UserBoard = ({
           folder={folder}
           folderList={userFolderList}
           onReassignComplete={() => {
-            updateOrdererInfoList();
+            updateUserList();
           }}
         />
       ));
@@ -160,7 +160,7 @@ const UserBoard = ({
 
   const handleUserPdfDownloadButtonClick = async () => {
     const zip = new JSZip();
-    const userList: OrdererInfo[] = filteredUserList.filter((f) =>
+    const userList: User[] = filteredUserList.filter((f) =>
       selectedUserList.find((userId) => f.userId === userId)
     );
     const pdfBlobList: PdfBlob[] = [];
@@ -214,7 +214,7 @@ const UserBoard = ({
 
       const pdfBlob = await pdf(
         <CounselingIntakeForm
-          ordererInfo={userValues}
+          userInfo={userValues}
           selectedInfoList={selectedInfoList}
           imageUrlList={imageUrlList}
           userId={user.userId}
@@ -243,7 +243,7 @@ const UserBoard = ({
   };
 
   useEffect(() => {
-    updateOrdererInfoList();
+    updateUserList();
     getProductList(
       (data) => {
         setProductList(data);
@@ -314,7 +314,7 @@ const UserBoard = ({
       <UserTable
         folder={folder}
         folderList={userFolderList}
-        userInfoList={filteredUserList}
+        userList={filteredUserList}
         setSelectedUserList={setSelectedUserList}
       />
     </StyledUserBoard>

--- a/src/components/manager/user/UserCopyModal.tsx
+++ b/src/components/manager/user/UserCopyModal.tsx
@@ -13,7 +13,7 @@ import {
   optionsToCopyList,
   SelectedOptions,
 } from "@/components/manager/user/util";
-import { OrdererInfo } from "@/const";
+import { User } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -54,7 +54,7 @@ const UserCopyModal = ({
 }: {
   isModalOpen: boolean;
   onModalClose: () => void;
-  selectedUserList: OrdererInfo[];
+  selectedUserList: User[];
 }) => {
   const [isSelectedAllOptions, setIsSelectedAllOptions] =
     useState<boolean>(true);
@@ -90,7 +90,7 @@ const UserCopyModal = ({
     });
   };
 
-  const handleUserInfoCopy = async () => {
+  const handleUserCopy = async () => {
     const clipboardData: string[] = [];
     const selectedOptionList = Object.keys(selectedOptionsObj).filter(
       (key) => selectedOptionsObj[key]
@@ -99,7 +99,7 @@ const UserCopyModal = ({
     const titleData = selectedOptionList.flatMap(getTitleData);
     clipboardData.push(titleData.join("\t"));
 
-    const getRowData = (user: OrdererInfo): string[] => {
+    const getRowData = (user: User): string[] => {
       return selectedOptionList
         .map((option) => {
           switch (option) {
@@ -195,7 +195,7 @@ const UserCopyModal = ({
           ))}
         </div>
         <DialogActions>
-          <Button onClick={handleUserInfoCopy} ref={copyButtonRef}>
+          <Button onClick={handleUserCopy} ref={copyButtonRef}>
             복사
           </Button>
           <Button onClick={onModalClose}>닫기</Button>

--- a/src/components/manager/user/UserDetailModal.tsx
+++ b/src/components/manager/user/UserDetailModal.tsx
@@ -13,8 +13,8 @@ import {
   userMetadataColumns1,
   userMetadataColumns2,
 } from "@/components/manager/user/const";
-import { handleUserInfoForOrder } from "@/components/manager/user/util";
-import { OrdererInfo } from "@/const";
+import { handleUserForOrder } from "@/components/manager/user/util";
+import { User } from "@/const";
 
 const StyledModalContainer = styled.div`
   display: flex;
@@ -48,11 +48,11 @@ const StyledCopyButton = styled(Button)`
 const UserDetailModal = ({
   isModalOpen,
   onModalClose,
-  modalUserInfoData,
+  modalUserData,
 }: {
   isModalOpen: boolean;
   onModalClose: () => void;
-  modalUserInfoData: OrdererInfo;
+  modalUserData: User;
 }) => {
   const {
     userId,
@@ -69,9 +69,9 @@ const UserDetailModal = ({
     remark1,
     remark2,
     metadata: { submissionTime, folderId },
-  } = modalUserInfoData;
+  } = modalUserData;
 
-  const orderRows = handleUserInfoForOrder(hopeProducts);
+  const orderRows = handleUserForOrder(hopeProducts);
   const copyButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleCopyClipBoard = async () => {

--- a/src/components/manager/user/UserTable.tsx
+++ b/src/components/manager/user/UserTable.tsx
@@ -11,32 +11,32 @@ import {
   UserTableRow,
 } from "@/components/manager/user/const";
 import UserDetailModal from "@/components/manager/user/UserDetailModal";
-import { handleUserInfoListForTable } from "@/components/manager/user/util";
-import { Folder, OrdererInfo } from "@/const";
+import { handleUserListForTable } from "@/components/manager/user/util";
+import { Folder, User } from "@/const";
 
 const UserTable = ({
   folder,
   folderList,
-  userInfoList,
+  userList,
   setSelectedUserList,
 }: {
   folder: Folder;
   folderList: Folder[];
-  userInfoList: OrdererInfo[];
+  userList: User[];
   setSelectedUserList: Dispatch<SetStateAction<string[]>>;
 }) => {
-  const tableRows = handleUserInfoListForTable(userInfoList, folderList);
+  const tableRows = handleUserListForTable(userList, folderList);
   const overlay = useOverlay();
 
   const handleRemarkUpdate = async (
     row: UserTableRow,
     old: UserTableRow
   ): Promise<UserTableRow> => {
-    row.__user_info__.remark1 = row.remark1;
-    row.__user_info__.remark2 = row.remark2;
+    row.__user__.remark1 = row.remark1;
+    row.__user__.remark2 = row.remark2;
     try {
       await editUserRemark(
-        row.__user_info__,
+        row.__user__,
         () => {},
         (e) => {
           throw e;
@@ -44,8 +44,8 @@ const UserTable = ({
       );
       return row;
     } catch (e) {
-      old.__user_info__.remark1 = old.remark1;
-      old.__user_info__.remark2 = old.remark2;
+      old.__user__.remark1 = old.remark1;
+      old.__user__.remark2 = old.remark2;
       overlay.open(({ isOpen, close }) => (
         <MessageDialog
           isDialogOpen={isOpen}
@@ -85,7 +85,7 @@ const UserTable = ({
               <UserDetailModal
                 isModalOpen={isOpen}
                 onModalClose={close}
-                modalUserInfoData={cell.row.__user_info__}
+                modalUserData={cell.row.__user__}
               />
             ));
           }

--- a/src/components/manager/user/const.ts
+++ b/src/components/manager/user/const.ts
@@ -1,6 +1,6 @@
 import { GridColDef } from "@mui/x-data-grid";
 
-import { OrdererInfo } from "@/const";
+import { User } from "@/const";
 
 export const tableColumns: GridColDef[] = [
   { field: "id", headerName: "ID", width: 80 },
@@ -105,7 +105,7 @@ export type UserTableRow = {
   remark2: string;
   folderId: string;
   folderName: string;
-  __user_info__: OrdererInfo;
+  __user__: User;
 };
 
 export interface PdfBlob {

--- a/src/components/manager/user/util.ts
+++ b/src/components/manager/user/util.ts
@@ -1,12 +1,12 @@
 import { UserTableRow } from "@/components/manager/user/const";
-import { Folder, OrdererInfo } from "@/const";
+import { Folder, User } from "@/const";
 
-export const handleUserInfoListForTable = (
-  userInfoList: OrdererInfo[],
+export const handleUserListForTable = (
+  userList: User[],
   folderList: Folder[]
 ): UserTableRow[] => {
   return (
-    userInfoList?.map((userInfo) => {
+    userList?.map((user) => {
       const {
         personalInfo: {
           name,
@@ -18,7 +18,7 @@ export const handleUserInfoListForTable = (
         remark1,
         remark2,
         metadata: { folderId },
-      } = userInfo;
+      } = user;
 
       return {
         id: userId,
@@ -32,13 +32,13 @@ export const handleUserInfoListForTable = (
         folderId,
         folderName:
           folderList.find((f) => f.id === folderId)?.name ?? "Not Found",
-        __user_info__: userInfo,
+        __user__: user,
       };
     }) ?? []
   );
 };
 
-export const handleUserInfoForOrder = (
+export const handleUserForOrder = (
   hopeProducts: [
     {
       colorCardQuantity: number;

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import QrScannerPage from "@/components/pages/QrScannerPage";
 import SubmissionCompletePage from "@/components/pages/SubmissionCompletePage";
 import ToBuyListPage from "@/components/pages/ToBuyListPage";
-import UserInfoSubmissionPage from "@/components/pages/UserSubmissionPage";
+import UserSubmissionPage from "@/components/pages/UserSubmissionPage";
 import WeChatFriendGuidePage from "@/components/pages/WeChatFriendGuidePage";
 import { BottomAppBar, TitleAppBar } from "@/components/user/AppBar";
 import RetryButton from "@/components/user/RetryButton";
@@ -30,7 +30,7 @@ const MainPage = () => {
           </Suspense>
         </ErrorBoundary>
       )}
-      {isPageName("info") && <UserInfoSubmissionPage />}
+      {isPageName("info") && <UserSubmissionPage />}
       {isPageName("wechat") && <WeChatFriendGuidePage />}
       {isPageName("complete") && <SubmissionCompletePage />}
       <BottomAppBar />

--- a/src/components/pages/UserSubmissionPage.tsx
+++ b/src/components/pages/UserSubmissionPage.tsx
@@ -11,8 +11,8 @@ import {
   AddressCheckbox,
   StyledStepper,
 } from "@/components/user/userSubmission/FormItems";
-import OrdererInfo from "@/components/user/userSubmission/OrdererInfo";
 import ShippingAddress from "@/components/user/userSubmission/ShippingAddress";
+import UserInfo from "@/components/user/userSubmission/UserInfo";
 
 const UserSubmissionPage = () => {
   const { t } = useTranslation();
@@ -59,7 +59,7 @@ const UserSubmissionPage = () => {
                 </AddressBox>
               )}
               <StepContent>
-                {index === 0 && <OrdererInfo />}
+                {index === 0 && <UserInfo />}
                 {index === 1 && <CompanyAddress />}
                 {index === 2 && <ShippingAddress />}
               </StepContent>

--- a/src/components/user/AppBar.tsx
+++ b/src/components/user/AppBar.tsx
@@ -205,7 +205,7 @@ const BottomAppBar = () => {
   useEffect(() => {
     setCounselingIntakeFormData(
       <CounselingIntakeForm
-        ordererInfo={values}
+        userInfo={values}
         selectedInfoList={selectedInfoList}
         imageUrlList={imageUrlList}
         userId={userId}

--- a/src/components/user/userSubmission/UserInfo.tsx
+++ b/src/components/user/userSubmission/UserInfo.tsx
@@ -9,7 +9,7 @@ import {
   UserSelect,
 } from "@/components/user/userSubmission/FormItems";
 
-const OrdererInfo = () => {
+const UserInfo = () => {
   const { t } = useTranslation();
   const { values }: FormikContextType<FormType> = useFormikContext();
 
@@ -37,4 +37,4 @@ const OrdererInfo = () => {
   );
 };
 
-export default OrdererInfo;
+export default UserInfo;

--- a/src/const.ts
+++ b/src/const.ts
@@ -20,7 +20,7 @@ export interface Product {
   metadata: ProductMetadata;
 }
 
-interface OrdererInfoMetadata {
+interface UserMetadata {
   documentId: string;
   userId: string;
   submissionTime: string;
@@ -28,7 +28,7 @@ interface OrdererInfoMetadata {
   language: Language;
 }
 
-export interface OrdererInfo {
+export interface User {
   userId: string;
   hopeProducts: [
     {
@@ -69,7 +69,7 @@ export interface OrdererInfo {
   };
   remark1: string;
   remark2: string;
-  metadata: OrdererInfoMetadata;
+  metadata: UserMetadata;
 }
 
 export interface Folder {

--- a/src/hooks/user/useInitialFormikValues.ts
+++ b/src/hooks/user/useInitialFormikValues.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useSetRecoilState } from "recoil";
 
-import { submitOrdererInfo } from "@/api";
+import { submitUser } from "@/api";
 import { FormType } from "@/components/const";
 import { validationSchema } from "@/components/user/validation";
 import dayjs from "@/dayjsConfig";
@@ -60,7 +60,7 @@ const useInitialFormikValues = () => {
       isSameAddress,
       productLengthUnit,
     } = form;
-    await submitOrdererInfo(
+    await submitUser(
       JSON.stringify({
         submissionTime: dayjs().format("YYYY-MM-DD HH:mm"),
         hopeProducts: Object.entries(selectedInfoList).map(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { OrdererInfo, Product } from "@/const";
+import { Product, User } from "@/const";
 
 export const transformProductForFolderUpdate = (
   product: Product,
@@ -17,7 +17,7 @@ export const transformProductForFolderUpdate = (
 };
 
 export const transformUserForUpdate = (
-  user: OrdererInfo,
+  user: User,
   folderId?: string
 ): string => {
   const { metadata, userId, ...rest } = user;


### PR DESCRIPTION
### 바뀐 이름들
UserInfo -> User
__user_info__ -> __user__
interface OrdererInfo -> User
컴포넌트 OrdererInfo -> UserInfo
CounselingIntakeForm 파라미터 ordererInfo -> userInfo

---

컴포넌트 OrdererInfo와 CounselingIntakeForm 파라미터 ordererInfo의 경우는 API에서 받아오는 user 정보가 아니라 유저가 form에 입력하는 유저 정보에 해당하기 때문에 별도의 이름이 필요하다고 판단했습니다.
현재는 이에 대한 type 명이 FormType이지만 추후 유저 Formik 리팩토링에서 이를 UserInfo로 네이밍을 바꾸고자 합니다.



