### PR TITLE
http onSuccess, onFail에서 try catch로 변경

### DIFF
--- a/src/api/auth/getCookie.ts
+++ b/src/api/auth/getCookie.ts
@@ -1,9 +1,6 @@
 import { ApiGetFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const getCookie: ApiGetFunction<SucceedResponse> = (
-  onSuccess,
-  onFail
-) => {
-  return http.get(`/cookie`, { credentials: "include" }, onSuccess, onFail);
+export const getCookie: ApiGetFunction<SucceedResponse> = () => {
+  return http.get(`/cookie`, { credentials: "include" });
 };

--- a/src/api/auth/postLogin.ts
+++ b/src/api/auth/postLogin.ts
@@ -1,16 +1,6 @@
 import { ApiModifyFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const postLogin: ApiModifyFunction<SucceedResponse> = (
-  body,
-  onSuccess,
-  onFail
-) => {
-  return http.post(
-    `/login`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+export const postLogin: ApiModifyFunction<SucceedResponse> = (body) => {
+  return http.post(`/login`, { credentials: "include" }, body);
 };

--- a/src/api/const.ts
+++ b/src/api/const.ts
@@ -11,15 +11,9 @@ export interface ErrorResponse {
 export type SuccessCallback<T> = (data: T) => void;
 export type FailCallback = (error: Error) => void;
 
-export type ApiGetFunction<T> = (
-  onSuccess: SuccessCallback<T>,
-  onFail: FailCallback,
-  targetId?: string
-) => Promise<void>;
+export type ApiGetFunction<T> = (targetId?: string) => Promise<T>;
 
 export type ApiModifyFunction<T> = (
   body: BodyInit | null | undefined,
-  onSuccess: SuccessCallback<T>,
-  onFail: FailCallback,
   targetId?: string
-) => Promise<void>;
+) => Promise<T>;

--- a/src/api/folders/deleteFolder.ts
+++ b/src/api/folders/deleteFolder.ts
@@ -3,15 +3,7 @@ import http from "@/api/http";
 
 export const deleteFolder: ApiModifyFunction<SucceedResponse> = (
   body,
-  onSuccess,
-  onFail,
   targetId
 ) => {
-  return http.delete(
-    `/folders/${targetId}`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+  return http.delete(`/folders/${targetId}`, { credentials: "include" }, body);
 };

--- a/src/api/folders/getFolderList.ts
+++ b/src/api/folders/getFolderList.ts
@@ -2,6 +2,6 @@ import { ApiGetFunction } from "@/api/const";
 import http from "@/api/http";
 import { Folder } from "@/const";
 
-export const getFolderList: ApiGetFunction<Folder[]> = (onSuccess, onFail) => {
-  return http.get(`/folders`, { credentials: "include" }, onSuccess, onFail);
+export const getFolderList: ApiGetFunction<Folder[]> = () => {
+  return http.get(`/folders`, { credentials: "include" });
 };

--- a/src/api/folders/patchFolder.ts
+++ b/src/api/folders/patchFolder.ts
@@ -3,15 +3,7 @@ import http from "@/api/http";
 
 export const patchFolder: ApiModifyFunction<SucceedResponse> = (
   body,
-  onSuccess,
-  onFail,
   targetId
 ) => {
-  return http.patch(
-    `/folders/${targetId}`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+  return http.patch(`/folders/${targetId}`, { credentials: "include" }, body);
 };

--- a/src/api/folders/postFolder.ts
+++ b/src/api/folders/postFolder.ts
@@ -1,16 +1,6 @@
 import { ApiModifyFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const postFolder: ApiModifyFunction<SucceedResponse> = (
-  body,
-  onSuccess,
-  onFail
-) => {
-  return http.post(
-    `/folders`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+export const postFolder: ApiModifyFunction<SucceedResponse> = (body) => {
+  return http.post(`/folders`, { credentials: "include" }, body);
 };

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,9 +1,4 @@
-import {
-  API_VERSION,
-  ErrorResponse,
-  FailCallback,
-  SuccessCallback,
-} from "@/api/const";
+import { API_VERSION, ErrorResponse } from "@/api/const";
 import { SERVER_URL } from "@/components/const";
 
 const isErrorResponse = (data: unknown): data is ErrorResponse => {
@@ -19,26 +14,12 @@ const handleResponse = <T>(res: Response): Promise<T> =>
   });
 
 const http = {
-  get: <T>(
-    path: string,
-    options = {},
-    onSuccess: SuccessCallback<T>,
-    onFail: FailCallback
-  ) =>
+  get: <T>(path: string, options = {}) =>
     fetch(`${SERVER_URL}${API_VERSION}${path}`, {
       method: "GET",
       ...options,
-    })
-      .then((res) => handleResponse<T>(res))
-      .then(onSuccess)
-      .catch(onFail),
-  post: <T>(
-    path: string,
-    options = {},
-    body: BodyInit | null | undefined,
-    onSuccess: SuccessCallback<T>,
-    onFail: FailCallback
-  ) =>
+    }).then((res) => handleResponse<T>(res)),
+  post: <T>(path: string, options = {}, body: BodyInit | null | undefined) =>
     fetch(`${SERVER_URL}${API_VERSION}${path}`, {
       method: "POST",
       headers: {
@@ -46,17 +27,8 @@ const http = {
       },
       ...options,
       body,
-    })
-      .then((res) => handleResponse<T>(res))
-      .then(onSuccess)
-      .catch(onFail),
-  put: <T>(
-    path: string,
-    options = {},
-    body: BodyInit | null | undefined,
-    onSuccess: SuccessCallback<T>,
-    onFail: FailCallback
-  ) =>
+    }).then((res) => handleResponse<T>(res)),
+  put: <T>(path: string, options = {}, body: BodyInit | null | undefined) =>
     fetch(`${SERVER_URL}${API_VERSION}${path}`, {
       method: "PUT",
       headers: {
@@ -64,17 +36,8 @@ const http = {
       },
       ...options,
       body,
-    })
-      .then((res) => handleResponse<T>(res))
-      .then(onSuccess)
-      .catch(onFail),
-  patch: <T>(
-    path: string,
-    options = {},
-    body: BodyInit | null | undefined,
-    onSuccess: SuccessCallback<T>,
-    onFail: FailCallback
-  ) =>
+    }).then((res) => handleResponse<T>(res)),
+  patch: <T>(path: string, options = {}, body: BodyInit | null | undefined) =>
     fetch(`${SERVER_URL}${API_VERSION}${path}`, {
       method: "PATCH",
       headers: {
@@ -82,17 +45,8 @@ const http = {
       },
       ...options,
       body,
-    })
-      .then((res) => handleResponse<T>(res))
-      .then(onSuccess)
-      .catch(onFail),
-  delete: <T>(
-    path: string,
-    options = {},
-    body: BodyInit | null | undefined,
-    onSuccess: SuccessCallback<T>,
-    onFail: FailCallback
-  ) =>
+    }).then((res) => handleResponse<T>(res)),
+  delete: <T>(path: string, options = {}, body: BodyInit | null | undefined) =>
     fetch(`${SERVER_URL}${API_VERSION}${path}`, {
       method: "DELETE",
       headers: {
@@ -100,10 +54,7 @@ const http = {
       },
       ...options,
       body,
-    })
-      .then((res) => handleResponse<T>(res))
-      .then(onSuccess)
-      .catch(onFail),
+    }).then((res) => handleResponse<T>(res)),
 };
 
 export default http;

--- a/src/api/products/deleteProduct.ts
+++ b/src/api/products/deleteProduct.ts
@@ -3,15 +3,7 @@ import http from "@/api/http";
 
 export const deleteProduct: ApiModifyFunction<SucceedResponse> = (
   body,
-  onSuccess,
-  onFail,
   targetId
 ) => {
-  return http.delete(
-    `/products/${targetId}`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+  return http.delete(`/products/${targetId}`, { credentials: "include" }, body);
 };

--- a/src/api/products/getProductList.ts
+++ b/src/api/products/getProductList.ts
@@ -2,9 +2,6 @@ import { ApiGetFunction } from "@/api/const";
 import http from "@/api/http";
 import { Product } from "@/const";
 
-export const getProductList: ApiGetFunction<Product[]> = (
-  onSuccess,
-  onFail
-) => {
-  return http.get(`/products`, undefined, onSuccess, onFail);
+export const getProductList: ApiGetFunction<Product[]> = () => {
+  return http.get(`/products`, undefined);
 };

--- a/src/api/products/postProduct.ts
+++ b/src/api/products/postProduct.ts
@@ -1,16 +1,6 @@
 import { ApiModifyFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const postProduct: ApiModifyFunction<SucceedResponse> = (
-  body,
-  onSuccess,
-  onFail
-) => {
-  return http.post(
-    `/products`,
-    { credentials: "include", headers: {} },
-    body,
-    onSuccess,
-    onFail
-  );
+export const postProduct: ApiModifyFunction<SucceedResponse> = (body) => {
+  return http.post(`/products`, { credentials: "include", headers: {} }, body);
 };

--- a/src/api/products/postProductList.ts
+++ b/src/api/products/postProductList.ts
@@ -1,16 +1,6 @@
 import { ApiModifyFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const postProductList: ApiModifyFunction<SucceedResponse> = (
-  body,
-  onSuccess,
-  onFail
-) => {
-  return http.post(
-    `/products/batch`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+export const postProductList: ApiModifyFunction<SucceedResponse> = (body) => {
+  return http.post(`/products/batch`, { credentials: "include" }, body);
 };

--- a/src/api/products/putProduct.ts
+++ b/src/api/products/putProduct.ts
@@ -2,17 +2,10 @@ import { ApiModifyFunction } from "@/api/const";
 import http from "@/api/http";
 import { Product } from "@/const";
 
-export const putProduct: ApiModifyFunction<Product> = (
-  body,
-  onSuccess,
-  onFail,
-  targetId
-) => {
+export const putProduct: ApiModifyFunction<Product> = (body, targetId) => {
   return http.put(
     `/products/${targetId}`,
     { credentials: "include", headers: {} },
-    body,
-    onSuccess,
-    onFail
+    body
   );
 };

--- a/src/api/text/getText.ts
+++ b/src/api/text/getText.ts
@@ -1,9 +1,6 @@
 import { ApiGetFunction } from "@/api/const";
 import http from "@/api/http";
 
-export const getText: ApiGetFunction<{ text: string }> = (
-  onSuccess,
-  onFail
-) => {
-  return http.get(`/text`, undefined, onSuccess, onFail);
+export const getText: ApiGetFunction<{ text: string }> = () => {
+  return http.get(`/text`, undefined);
 };

--- a/src/api/text/putText.ts
+++ b/src/api/text/putText.ts
@@ -1,10 +1,6 @@
 import { ApiModifyFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const putText: ApiModifyFunction<SucceedResponse> = (
-  body,
-  onSuccess,
-  onFail
-) => {
-  return http.put(`/text`, { credentials: "include" }, body, onSuccess, onFail);
+export const putText: ApiModifyFunction<SucceedResponse> = (body) => {
+  return http.put(`/text`, { credentials: "include" }, body);
 };

--- a/src/api/users/deleteUser.ts
+++ b/src/api/users/deleteUser.ts
@@ -3,15 +3,7 @@ import http from "@/api/http";
 
 export const deleteUser: ApiModifyFunction<SucceedResponse> = (
   body,
-  onSuccess,
-  onFail,
   targetId
 ) => {
-  return http.delete(
-    `/users/${targetId}`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+  return http.delete(`/users/${targetId}`, { credentials: "include" }, body);
 };

--- a/src/api/users/getUserList.ts
+++ b/src/api/users/getUserList.ts
@@ -2,6 +2,6 @@ import { ApiGetFunction } from "@/api/const";
 import http from "@/api/http";
 import { User } from "@/const";
 
-export const getUserList: ApiGetFunction<User[]> = (onSuccess, onFail) => {
-  return http.get(`/users`, { credentials: "include" }, onSuccess, onFail);
+export const getUserList: ApiGetFunction<User[]> = () => {
+  return http.get(`/users`, { credentials: "include" });
 };

--- a/src/api/users/postUser.ts
+++ b/src/api/users/postUser.ts
@@ -2,6 +2,6 @@ import { ApiModifyFunction } from "@/api/const";
 import http from "@/api/http";
 import { User } from "@/const";
 
-export const postUser: ApiModifyFunction<User> = (body, onSuccess, onFail) => {
-  return http.post(`/users`, undefined, body, onSuccess, onFail);
+export const postUser: ApiModifyFunction<User> = (body) => {
+  return http.post(`/users`, undefined, body);
 };

--- a/src/api/users/putUser.ts
+++ b/src/api/users/putUser.ts
@@ -1,17 +1,6 @@
 import { ApiModifyFunction, SucceedResponse } from "@/api/const";
 import http from "@/api/http";
 
-export const putUser: ApiModifyFunction<SucceedResponse> = (
-  body,
-  onSuccess,
-  onFail,
-  targetId
-) => {
-  return http.put(
-    `/users/${targetId}`,
-    { credentials: "include" },
-    body,
-    onSuccess,
-    onFail
-  );
+export const putUser: ApiModifyFunction<SucceedResponse> = (body, targetId) => {
+  return http.put(`/users/${targetId}`, { credentials: "include" }, body);
 };

--- a/src/components/manager/Dashboard.tsx
+++ b/src/components/manager/Dashboard.tsx
@@ -1,8 +1,10 @@
 import styled from "@emotion/styled";
+import { useOverlay } from "@toss/use-overlay";
 import { useEffect, useState } from "react";
 
 import { getFolderList } from "@/api/folders";
 import Icons from "@/components/common/Icons";
+import MessageDialog from "@/components/common/MessageDialog";
 import { initialFolderList } from "@/components/manager/const";
 import { StyledAppBar } from "@/components/manager/DashboardItems";
 import Menu from "@/components/manager/Menu";
@@ -26,16 +28,21 @@ const Dashboard = () => {
   );
   const [folderList, setFolderList] = useState<Folder[]>(initialFolderList);
   const [updateTrigger, setUpdateTrigger] = useState(0);
+  const overlay = useOverlay();
 
-  const handleFolderListUpdate = () => {
-    getFolderList(
-      (data) => {
-        setFolderList(data);
-      },
-      (e) => {
-        console.log(e);
-      }
-    );
+  const handleFolderListUpdate = async () => {
+    try {
+      const folderList = await getFolderList();
+      setFolderList(folderList);
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["폴더 불러오기 실패"]}
+        />
+      ));
+    }
   };
 
   const handleBoardUpdate = () => {

--- a/src/components/manager/LoginForm.tsx
+++ b/src/components/manager/LoginForm.tsx
@@ -11,21 +11,21 @@ import React from "react";
 import { postLogin } from "@/api/auth";
 
 const LoginForm = ({ setHasAuth }) => {
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const inputData = new FormData(event.currentTarget);
-    postLogin(
-      JSON.stringify({
-        email: inputData.get("email"),
-        password: inputData.get("password"),
-      }),
-      () => {
-        setHasAuth(true);
-      },
-      (e) => {
-        console.log(e);
-      }
-    );
+    try {
+      await postLogin(
+        JSON.stringify({
+          email: inputData.get("email"),
+          password: inputData.get("password"),
+        })
+      );
+      setHasAuth(true);
+    } catch (e) {
+      // NOTE: Formik으로 변경 후 errors에서 다룰 예정
+      console.log("로그인 실패");
+    }
   };
 
   return (

--- a/src/components/manager/folder/DataFolderReassignModal.tsx
+++ b/src/components/manager/folder/DataFolderReassignModal.tsx
@@ -55,25 +55,21 @@ const DataFolderReassignModal = ({
           }}
           validationSchema={folderSelectionSchema}
           onSubmit={async (values, { setSubmitting }) => {
-            await reassignFolder(
-              selectedDataList,
-              values.folderId,
-              () => {
-                setSubmitting(false);
-                onReassignComplete && onReassignComplete();
-                onModalClose();
-              },
-              () => {
-                setSubmitting(false);
-                overlay.open(({ isOpen, close }) => (
-                  <MessageDialog
-                    isDialogOpen={isOpen}
-                    onDialogClose={close}
-                    messageList={["폴더 이동 실패"]}
-                  />
-                ));
-              }
-            );
+            try {
+              await reassignFolder(selectedDataList, values.folderId);
+              onReassignComplete && onReassignComplete();
+              onModalClose();
+            } catch {
+              overlay.open(({ isOpen, close }) => (
+                <MessageDialog
+                  isDialogOpen={isOpen}
+                  onDialogClose={close}
+                  messageList={["폴더 이동 실패"]}
+                />
+              ));
+            } finally {
+              setSubmitting(false);
+            }
           }}
         >
           {({ isSubmitting, errors, touched, values, setFieldValue }) => (

--- a/src/components/manager/folder/FolderActionModal.tsx
+++ b/src/components/manager/folder/FolderActionModal.tsx
@@ -43,23 +43,19 @@ const FolderActionModal = ({
     initialValues: {},
     validateOnMount: true,
     onSubmit: async () => {
-      await deleteFolder(
-        undefined,
-        () => {
-          onFolderListUpdate();
-          onFolderDelete();
-        },
-        () => {
-          overlay.open(({ isOpen, close }) => (
-            <MessageDialog
-              isDialogOpen={isOpen}
-              onDialogClose={close}
-              messageList={["폴더 삭제 실패"]}
-            />
-          ));
-        },
-        id
-      );
+      try {
+        await deleteFolder(undefined, id);
+        onFolderListUpdate();
+        onFolderDelete();
+      } catch {
+        overlay.open(({ isOpen, close }) => (
+          <MessageDialog
+            isDialogOpen={isOpen}
+            onDialogClose={close}
+            messageList={["폴더 삭제 실패"]}
+          />
+        ));
+      }
     },
   });
 
@@ -73,25 +69,21 @@ const FolderActionModal = ({
           }}
           validationSchema={editionValidationSchema}
           onSubmit={async (values, { setSubmitting }) => {
-            await patchFolder(
-              JSON.stringify(values),
-              () => {
-                setSubmitting(false);
-                onFolderListUpdate();
-                onClose();
-              },
-              () => {
-                setSubmitting(false);
-                overlay.open(({ isOpen, close }) => (
-                  <MessageDialog
-                    isDialogOpen={isOpen}
-                    onDialogClose={close}
-                    messageList={["폴더 수정 실패"]}
-                  />
-                ));
-              },
-              id
-            );
+            try {
+              await patchFolder(JSON.stringify(values), id);
+              onFolderListUpdate();
+              onClose();
+            } catch {
+              overlay.open(({ isOpen, close }) => (
+                <MessageDialog
+                  isDialogOpen={isOpen}
+                  onDialogClose={close}
+                  messageList={["폴더 수정 실패"]}
+                />
+              ));
+            } finally {
+              setSubmitting(false);
+            }
           }}
         >
           {({ isSubmitting, errors, touched }) => (

--- a/src/components/manager/folder/FolderCreationModal.tsx
+++ b/src/components/manager/folder/FolderCreationModal.tsx
@@ -57,24 +57,21 @@ const FolderCreationModal = ({
           }}
           validationSchema={creationValidationSchema}
           onSubmit={async (values, { setSubmitting }) => {
-            await postFolder(
-              JSON.stringify(values),
-              () => {
-                setSubmitting(false);
-                onFolderListUpdate();
-                onClose();
-              },
-              () => {
-                setSubmitting(false);
-                overlay.open(({ isOpen, close }) => (
-                  <MessageDialog
-                    isDialogOpen={isOpen}
-                    onDialogClose={close}
-                    messageList={["폴더 생성 실패"]}
-                  />
-                ));
-              }
-            );
+            try {
+              await postFolder(JSON.stringify(values));
+              onFolderListUpdate();
+              onClose();
+            } catch {
+              overlay.open(({ isOpen, close }) => (
+                <MessageDialog
+                  isDialogOpen={isOpen}
+                  onDialogClose={close}
+                  messageList={["폴더 생성 실패"]}
+                />
+              ));
+            } finally {
+              setSubmitting(false);
+            }
           }}
         >
           {({ isSubmitting, errors, touched }) => (

--- a/src/components/manager/product/ExcelProductCreateModal.tsx
+++ b/src/components/manager/product/ExcelProductCreateModal.tsx
@@ -85,24 +85,23 @@ const ExcelProductCreateModal = ({
     reader.readAsArrayBuffer(file);
   };
 
-  const handleProductListCreate = () => {
-    postProductList(
-      transformProductExcelListToSubmitForm(newProductList, folder.id),
-      () => {
-        onProductListCreate();
-        onModalClose();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["제품 생성 실패"]}
-          />
-        ));
-        onModalClose();
-      }
-    );
+  const handleProductListCreate = async () => {
+    try {
+      await postProductList(
+        transformProductExcelListToSubmitForm(newProductList, folder.id)
+      );
+      onProductListCreate();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["제품 생성 실패"]}
+        />
+      ));
+    } finally {
+      onModalClose();
+    }
   };
 
   return (

--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -51,21 +51,19 @@ const ProductBoard = ({
   const [selectedProductList, setSelectedProductList] = useState<string[]>([]);
   const overlay = useOverlay();
 
-  const handleProductListUpdate = () => {
-    getProductList(
-      (data) => {
-        setProductList(data);
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 가져오기 실패"]}
-          />
-        ));
-      }
-    );
+  const handleProductListUpdate = async () => {
+    try {
+      const productList = await getProductList();
+      setProductList(productList);
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 가져오기 실패"]}
+        />
+      ));
+    }
   };
 
   const handleProductRestore = async () => {

--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -106,22 +106,19 @@ const ProductBoard = ({
     }
   };
 
-  const handleProductPermanentDelete = () => {
-    deleteProductList(
-      selectedProductList,
-      () => {
-        handleProductListUpdate();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 영구 삭제 실패"]}
-          />
-        ));
-      }
-    );
+  const handleProductPermanentDelete = async () => {
+    try {
+      await deleteProductList(selectedProductList);
+      handleProductListUpdate();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 영구 삭제 실패"]}
+        />
+      ));
+    }
   };
 
   const handleProductQrCodeCreate = async () => {

--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -68,46 +68,44 @@ const ProductBoard = ({
     );
   };
 
-  const handleProductRestore = () => {
-    reassignFolder(
-      filteredProductList.filter((f) =>
-        selectedProductList.find((productId) => f.productId === productId)
-      ),
-      PRODUCT_DEFAULT,
-      () => {
-        handleProductListUpdate();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 복구 실패"]}
-          />
-        ));
-      }
-    );
+  const handleProductRestore = async () => {
+    try {
+      await reassignFolder(
+        filteredProductList.filter((f) =>
+          selectedProductList.find((productId) => f.productId === productId)
+        ),
+        PRODUCT_DEFAULT
+      );
+      handleProductListUpdate();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 복구 실패"]}
+        />
+      ));
+    }
   };
 
-  const handleProductSoftDelete = () => {
-    reassignFolder(
-      filteredProductList.filter((f) =>
-        selectedProductList.find((productId) => f.productId === productId)
-      ),
-      PRODUCT_TRASH_CAN,
-      () => {
-        handleProductListUpdate();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 삭제 실패"]}
-          />
-        ));
-      }
-    );
+  const handleProductSoftDelete = async () => {
+    try {
+      await reassignFolder(
+        filteredProductList.filter((f) =>
+          selectedProductList.find((productId) => f.productId === productId)
+        ),
+        PRODUCT_TRASH_CAN
+      );
+      handleProductListUpdate();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 삭제 실패"]}
+        />
+      ));
+    }
   };
 
   const handleProductPermanentDelete = () => {

--- a/src/components/manager/product/ProductCreateModal.tsx
+++ b/src/components/manager/product/ProductCreateModal.tsx
@@ -35,7 +35,7 @@ const ProductCreateModal = ({
   const formik = useFormik({
     initialValues: productCreationInitialValues,
     validationSchema: productCreationSchema,
-    onSubmit: (form, { resetForm }) => {
+    onSubmit: async (form, { resetForm }) => {
       const newForm = {
         ...form,
         colors: form.colors.map((color, index) => {
@@ -58,23 +58,19 @@ const ProductCreateModal = ({
           formData.append(key, JSON.stringify(value));
         }
       });
-
-      postProduct(
-        formData,
-        () => {
-          resetForm();
-          onProductCreate();
-        },
-        (e) => {
-          overlay.open(({ isOpen, close }) => (
-            <MessageDialog
-              isDialogOpen={isOpen}
-              onDialogClose={close}
-              messageList={[e.message]}
-            />
-          ));
-        }
-      );
+      try {
+        await postProduct(formData);
+        resetForm();
+        onProductCreate();
+      } catch (e) {
+        overlay.open(({ isOpen, close }) => (
+          <MessageDialog
+            isDialogOpen={isOpen}
+            onDialogClose={close}
+            messageList={[e.message]}
+          />
+        ));
+      }
     },
   });
   const productIdRefs = useRef<HTMLInputElement>(null);

--- a/src/components/manager/product/ProductEditModal.tsx
+++ b/src/components/manager/product/ProductEditModal.tsx
@@ -34,7 +34,7 @@ const ProductEditModal = ({
     initialValues: productEditionInitialValues,
     validateOnMount: true,
     validationSchema: productEditionSchema,
-    onSubmit: (form) => {
+    onSubmit: async (form) => {
       const newForm = {
         ...form,
         colors: form.colors.map((color, index) => {
@@ -59,29 +59,25 @@ const ProductEditModal = ({
         }
       });
 
-      putProduct(
-        formData,
-        (product) => {
-          overlay.open(({ isOpen, close }) => (
-            <ProductDetailModal
-              modalProductData={product}
-              isModalOpen={isOpen}
-              onModalClose={close}
-            />
-          ));
-          onModalClose();
-        },
-        (e) => {
-          overlay.open(({ isOpen, close }) => (
-            <MessageDialog
-              isDialogOpen={isOpen}
-              onDialogClose={close}
-              messageList={[e.message]}
-            />
-          ));
-        },
-        product.productId
-      );
+      try {
+        const res = await putProduct(formData, product.productId);
+        overlay.open(({ isOpen, close }) => (
+          <ProductDetailModal
+            modalProductData={res}
+            isModalOpen={isOpen}
+            onModalClose={close}
+          />
+        ));
+        onModalClose();
+      } catch (e) {
+        overlay.open(({ isOpen, close }) => (
+          <MessageDialog
+            isDialogOpen={isOpen}
+            onDialogClose={close}
+            messageList={[e.message]}
+          />
+        ));
+      }
     },
   });
 

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -238,22 +238,24 @@ const UserBoard = ({
     link.click();
   };
 
+  const handleProductListUpdate = async () => {
+    try {
+      const productList = await getProductList();
+      setProductList(productList);
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["제품 목록 받아오기 실패"]}
+        />
+      ));
+    }
+  };
+
   useEffect(() => {
     updateUserList();
-    getProductList(
-      (data) => {
-        setProductList(data);
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["제품 목록 받아오기 실패"]}
-          />
-        ));
-      }
-    );
+    handleProductListUpdate();
   }, []);
 
   return (

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -60,21 +60,19 @@ const UserBoard = ({
   const overlay = useOverlay();
   const [productList, setProductList] = useState<Product[]>([]);
 
-  const updateUserList = () => {
-    getUserList(
-      (data) => {
-        setUserList(data);
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 가져오기 실패"]}
-          />
-        ));
-      }
-    );
+  const updateUserList = async () => {
+    try {
+      const userList = await getUserList();
+      setUserList(userList);
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 가져오기 실패"]}
+        />
+      ));
+    }
   };
 
   const handleUserRestore = async () => {
@@ -117,22 +115,19 @@ const UserBoard = ({
     }
   };
 
-  const handleUserPermanentDelete = () => {
-    deleteUserList(
-      selectedUserList,
-      () => {
-        updateUserList();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 영구 삭제 실패"]}
-          />
-        ));
-      }
-    );
+  const handleUserPermanentDelete = async () => {
+    try {
+      await deleteUserList(selectedUserList);
+      updateUserList();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 영구 삭제 실패"]}
+        />
+      ));
+    }
   };
 
   const handleUserFolderReassign = () => {

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -77,46 +77,44 @@ const UserBoard = ({
     );
   };
 
-  const handleUserRestore = () => {
-    reassignFolder(
-      filteredUserList.filter((f) =>
-        selectedUserList.find((userId) => f.userId === userId)
-      ),
-      USER_DEFAULT,
-      () => {
-        updateUserList();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 복구 실패"]}
-          />
-        ));
-      }
-    );
+  const handleUserRestore = async () => {
+    try {
+      await reassignFolder(
+        filteredUserList.filter((f) =>
+          selectedUserList.find((userId) => f.userId === userId)
+        ),
+        USER_DEFAULT
+      );
+      updateUserList();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 복구 실패"]}
+        />
+      ));
+    }
   };
 
-  const handleUserSoftDelete = () => {
-    reassignFolder(
-      filteredUserList.filter((f) =>
-        selectedUserList.find((userId) => f.userId === userId)
-      ),
-      USER_TRASH_CAN,
-      () => {
-        updateUserList();
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={["데이터 삭제 실패"]}
-          />
-        ));
-      }
-    );
+  const handleUserSoftDelete = async () => {
+    try {
+      await reassignFolder(
+        filteredUserList.filter((f) =>
+          selectedUserList.find((userId) => f.userId === userId)
+        ),
+        USER_TRASH_CAN
+      );
+      updateUserList();
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={close}
+          messageList={["데이터 삭제 실패"]}
+        />
+      ));
+    }
   };
 
   const handleUserPermanentDelete = () => {

--- a/src/components/manager/user/UserTable.tsx
+++ b/src/components/manager/user/UserTable.tsx
@@ -36,14 +36,7 @@ const UserTable = ({
     row.__user__.remark1 = row.remark1;
     row.__user__.remark2 = row.remark2;
     try {
-      await putUser(
-        transformUserForUpdate(row.__user__),
-        () => {},
-        (e) => {
-          throw e;
-        },
-        row.__user__.userId
-      );
+      await putUser(transformUserForUpdate(row.__user__), row.__user__.userId);
       return row;
     } catch (e) {
       old.__user__.remark1 = old.remark1;

--- a/src/components/manager/user/UserTextActionModal.tsx
+++ b/src/components/manager/user/UserTextActionModal.tsx
@@ -42,24 +42,22 @@ const UserTextActionModal = ({
   const [initialText, setInitialText] = useState("");
   const overlay = useOverlay();
 
-  const handleTextUpdate = () => {
-    getText(
-      ({ text }) => {
-        setInitialText(text);
-      },
-      () => {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={() => {
-              close();
-              onClose();
-            }}
-            messageList={["기존 텍스트 불러오기 실패"]}
-          />
-        ));
-      }
-    );
+  const handleTextUpdate = async () => {
+    try {
+      const { text } = await getText();
+      setInitialText(text);
+    } catch {
+      overlay.open(({ isOpen, close }) => (
+        <MessageDialog
+          isDialogOpen={isOpen}
+          onDialogClose={() => {
+            close();
+            onClose();
+          }}
+          messageList={["기존 텍스트 불러오기 실패"]}
+        />
+      ));
+    }
   };
 
   useEffect(() => {
@@ -84,32 +82,29 @@ const UserTextActionModal = ({
           enableReinitialize={true}
           validationSchema={validationSchema}
           onSubmit={async (values, { setSubmitting }) => {
-            await putText(
-              JSON.stringify(values),
-              () => {
-                setSubmitting(false);
-                overlay.open(({ isOpen, close }) => (
-                  <MessageDialog
-                    isDialogOpen={isOpen}
-                    onDialogClose={() => {
-                      close();
-                      onClose();
-                    }}
-                    messageList={["설정 텍스트 변경 성공"]}
-                  />
-                ));
-              },
-              () => {
-                setSubmitting(false);
-                overlay.open(({ isOpen, close }) => (
-                  <MessageDialog
-                    isDialogOpen={isOpen}
-                    onDialogClose={close}
-                    messageList={["설정 텍스트 변경 실패"]}
-                  />
-                ));
-              }
-            );
+            try {
+              await putText(JSON.stringify(values));
+              overlay.open(({ isOpen, close }) => (
+                <MessageDialog
+                  isDialogOpen={isOpen}
+                  onDialogClose={() => {
+                    close();
+                    onClose();
+                  }}
+                  messageList={["설정 텍스트 변경 성공"]}
+                />
+              ));
+            } catch {
+              overlay.open(({ isOpen, close }) => (
+                <MessageDialog
+                  isDialogOpen={isOpen}
+                  onDialogClose={close}
+                  messageList={["설정 텍스트 변경 실패"]}
+                />
+              ));
+            } finally {
+              setSubmitting(false);
+            }
           }}
         >
           {({ isSubmitting, errors, touched }) => (

--- a/src/components/pages/ManagerPage.tsx
+++ b/src/components/pages/ManagerPage.tsx
@@ -9,16 +9,19 @@ const ManagerPage = () => {
   const [isCookieAuthChecking, setIsCookieAuthChecking] = useState(true);
 
   useEffect(() => {
-    getCookie(
-      () => {
+    const handleAuthCheck = async () => {
+      try {
+        await getCookie();
         setHasAuth(true);
-        setIsCookieAuthChecking(false);
-      },
-      (e) => {
+      } catch (e) {
+        // NOTE: status 상태 코드도 에러 관리에 포함 후 console 제거 예정
         console.log(e);
+      } finally {
         setIsCookieAuthChecking(false);
       }
-    );
+    };
+
+    handleAuthCheck();
   }, []);
 
   if (isCookieAuthChecking) {

--- a/src/components/pages/UserSubmissionPage.tsx
+++ b/src/components/pages/UserSubmissionPage.tsx
@@ -72,6 +72,7 @@ const UserSubmissionPage = () => {
 
         if (isValid) {
           try {
+            // NOTE: submitForm은 Formik onSubmit와 동일
             await submitForm();
             setScannedItemList({});
             setSelectedInfoList({});
@@ -107,20 +108,15 @@ const UserSubmissionPage = () => {
     form: UserInfo,
     resetForm: (nextState?: Partial<FormikState<UserInfo>> | undefined) => void
   ) => {
-    await postUser(
+    const { userId } = await postUser(
       formatSubmitUserBody(
         form,
         dayjs().format("YYYY-MM-DD HH:mm"),
         i18n.language,
         selectedInfoList
-      ),
-      (res) => {
-        setUserId(res.userId);
-      },
-      (e) => {
-        throw e;
-      }
+      )
     );
+    setUserId(userId);
   };
 
   return (

--- a/src/recoil/user/atoms/fetchedItemListState.ts
+++ b/src/recoil/user/atoms/fetchedItemListState.ts
@@ -14,17 +14,14 @@ export const fetchedItemListSelector = selector<Product[]>({
   get: async ({ get }) => {
     get(fetchedItemListCounter);
 
-    const getProductListPromise = () =>
-      new Promise<Product[]>((resolve, reject) => {
-        getProductList(
-          (data) =>
-            resolve(
-              data.filter((d) => d.metadata.folderId !== PRODUCT_TRASH_CAN)
-            ),
-          (e) => reject(e)
-        );
-      });
-
-    return await getProductListPromise();
+    try {
+      const productList = await getProductList();
+      return productList.filter(
+        (product) => product.metadata.folderId !== PRODUCT_TRASH_CAN
+      );
+    } catch {
+      // NOTE: 오류 발생 시 빈 배열 반환
+      return [];
+    }
   },
 });

--- a/src/services/folders.ts
+++ b/src/services/folders.ts
@@ -1,4 +1,3 @@
-import { FailCallback, SucceedResponse, SuccessCallback } from "@/api/const";
 import { putProduct } from "@/api/products";
 import { putUser } from "@/api/users";
 import { Product, User } from "@/const";
@@ -9,29 +8,12 @@ import {
 
 export const reassignFolder = (
   dataList: User[] | Product[],
-  folderId: string,
-  onSuccess: SuccessCallback<SucceedResponse[] | Product[]>,
-  onFail: FailCallback
+  folderId: string
 ) => {
-  const promises: Promise<SucceedResponse | Product>[] = [];
-  dataList.forEach((d: User | Product) => {
-    promises.push(
-      new Promise((resolve, reject) => {
-        "productId" in d
-          ? putProduct(
-              transformProductForFolderUpdate(d, folderId),
-              resolve,
-              reject,
-              d.productId
-            )
-          : putUser(
-              transformUserForUpdate(d, folderId),
-              resolve,
-              reject,
-              d.userId
-            );
-      })
-    );
+  const promises = dataList.map((d: User | Product) => {
+    return "productId" in d
+      ? putProduct(transformProductForFolderUpdate(d, folderId), d.productId)
+      : putUser(transformUserForUpdate(d, folderId), d.userId);
   });
-  return Promise.all(promises).then(onSuccess).catch(onFail);
+  return Promise.all(promises);
 };

--- a/src/services/products.ts
+++ b/src/services/products.ts
@@ -1,16 +1,9 @@
-import { FailCallback, SucceedResponse, SuccessCallback } from "@/api/const";
 import { deleteProduct } from "@/api/products";
 
-export const deleteProductList = (
-  productList: string[],
-  onSuccess: SuccessCallback<SucceedResponse[]>,
-  onFail: FailCallback
-) => {
+export const deleteProductList = (productList: string[]) => {
   const deletePromises = productList.map((productId) => {
-    return new Promise((resolve, reject) => {
-      deleteProduct(undefined, resolve, reject, productId);
-    });
+    return deleteProduct(undefined, productId);
   });
 
-  return Promise.all(deletePromises).then(onSuccess).catch(onFail);
+  return Promise.all(deletePromises);
 };

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,18 +1,9 @@
-import { FailCallback, SucceedResponse, SuccessCallback } from "@/api/const";
 import { deleteUser } from "@/api/users";
 
-export const deleteUserList = (
-  ordererList: string[],
-  onSuccess: SuccessCallback<SucceedResponse[]>,
-  onFail: FailCallback
-) => {
-  const deletePromises: Promise<SucceedResponse>[] = ordererList.map(
-    (ordererId) => {
-      return new Promise((resolve, reject) => {
-        deleteUser(undefined, resolve, reject, ordererId);
-      });
-    }
-  );
+export const deleteUserList = (ordererList: string[]) => {
+  const deletePromises = ordererList.map((ordererId) => {
+    return deleteUser(undefined, ordererId);
+  });
 
-  return Promise.all(deletePromises).then(onSuccess).catch(onFail);
+  return Promise.all(deletePromises);
 };


### PR DESCRIPTION

## 개요

기존 API 함수에서 파라미터로 onSuccess, onFail로 받던 구조에선 몇 가지 문제가 있었습니다.
1. 동기 비동기 처리가 더 복잡해진다.
2. 굳이 붙지 않아도 될 async가 또 붙는다.
3. 코드 흐름이 불규칙적이다. (위에서부터 성공 → 실패 → 성공 이후 로직)
4. lint의 no-floating-promises 경고에 대해 무방비하다.

``` tsx
const handleUserSoftDelete = async () => {
    await reassignFolder(
      filteredUserList.filter((f) =>
        selectedUserList.find((userId) => f.userId === userId)
      ),
      USER_TRASH_CAN,
      async () => {
      // 성공 처리 1
        await updateUserList();
        console.log("user update done");
      },
      () => {
      // 실패 처리
        overlay.open(({ isOpen, close }) => (
          <MessageDialog
            isDialogOpen={isOpen}
            onDialogClose={close}
            messageList={["데이터 삭제 실패"]}
          />
        ));
      }
    );
    // 성공 처리 2
    console.log("reassignFolder done?");
  };
```

위의 코드에서 문제점들이 잘 드러난다고 생각합니다.

따라서 파라미터로 onSuccess, onFail을 받는 구문을 모두 외부에서 try catch로 처리하는 방향으로 개선했습니다.

## 변경 사항
- API 함수들이 onSuccess, onFail을 받지 않고 성공, 실패에 대해 try catch로 처리하게 변경
- 기존 API 호출은 하지만 async를 붙이지 않아 Promise를 반환하지 않던 함수들에 대해 async await 처리를 해줬습니다.

## To Reviewers

try catch로 바꾸는 과정에서 일부 해석이 필요한 코드들(e.g. console.log)에는 // NOTE: 로 주석을 달아놓았습니다.
이어서 no-floating-promises를 해결하고자 합니다.