### PR TITLE
userSubmission 타입 지정 및 컨벤션 적용 #295

### DIFF
--- a/src/components/pages/ToBuyListPage.tsx
+++ b/src/components/pages/ToBuyListPage.tsx
@@ -65,6 +65,7 @@ const ProductLists = styled.div`
 `;
 
 const StyledSwitch = () => {
+  // NOTE: formik이 아닌 recoil로 처리하도록 수정 필요
   const { values, setFieldValue } = useFormikContext<UserInfo>();
 
   return (

--- a/src/components/pages/UserSubmissionPage.tsx
+++ b/src/components/pages/UserSubmissionPage.tsx
@@ -2,7 +2,7 @@ import { useOverlay } from "@toss/use-overlay";
 import { Formik, FormikState } from "formik";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 
 import { postUser } from "@/api/users";
 import CounselingIntakeForm from "@/components/common/CounselingIntakeForm";
@@ -29,24 +29,22 @@ import { userIdState } from "@/recoil/user/atoms/userIdState";
 const UserSubmissionPage = () => {
   const { t, i18n } = useTranslation();
   const overlay = useOverlay();
-  const selectedInfoList = useRecoilValue(selectedInfoListState);
-  const setUserId = useSetRecoilState(userIdState);
+  const userFormRef = useRef<UserFormHandle>(null);
+  const { goToNextPage, goToPage, setPageAction } = usePageRouter();
+  const { setScannedItemList } = useScannedItemList();
+  const { setSelectedInfoList } = useSelectedInfoList();
   const [storedFormikValues, handleFormikValuesSyncToLocalStorage] =
     useLocalStorageState({
       key: "form",
       value: userInfoInitialValues,
     });
-  const userFormRef = useRef<UserFormHandle>(null);
-  const { setScannedItemList } = useScannedItemList();
-  const { setSelectedInfoList } = useSelectedInfoList();
-  const setImageUrlList = useSetRecoilState(imageUrlListState);
-  const { goToNextPage, goToPage, setPageAction } = usePageRouter();
+  const selectedInfoList = useRecoilValue(selectedInfoListState);
   const setMessageSnackBarState = useSetRecoilState(messageSnackBarState);
-  const userId = useRecoilValue(userIdState);
   const setCounselingIntakeFormData = useSetRecoilState(
     counselingIntakeFormDataState
   );
-  const imageUrlList = useRecoilValue(imageUrlListState);
+  const [userId, setUserId] = useRecoilState(userIdState);
+  const [imageUrlList, setImageUrlList] = useRecoilState(imageUrlListState);
 
   useEffect(() => {
     if (userFormRef.current) {

--- a/src/components/pages/UserSubmissionPage.tsx
+++ b/src/components/pages/UserSubmissionPage.tsx
@@ -107,12 +107,12 @@ const UserSubmissionPage = () => {
     resetForm: (nextState?: Partial<FormikState<UserInfo>> | undefined) => void
   ) => {
     const { userId } = await postUser(
-      formatSubmitUserBody(
+      formatSubmitUserBody({
         form,
-        dayjs().format("YYYY-MM-DD HH:mm"),
-        i18n.language,
-        selectedInfoList
-      )
+        submissionTime: dayjs().format("YYYY-MM-DD HH:mm"),
+        language: i18n.language,
+        selectedInfoList,
+      })
     );
     setUserId(userId);
   };

--- a/src/components/user/userSubmission/CompanyAddress.tsx
+++ b/src/components/user/userSubmission/CompanyAddress.tsx
@@ -39,16 +39,19 @@ const CompanyAddress = ({ formik }: { formik: FormikProps<UserInfo> }) => {
         label={t("Postal Code")}
         name="coPostalCode"
         disable={values.businessType === "Student"}
+        formik={formik}
       />
       <UserInput
         label={t("Address")}
         name="coAddress"
         disable={values.businessType === "Student"}
+        formik={formik}
       />
       <UserInput
         label={t("Detail Address")}
         name="coDetailAddress"
         disable={values.businessType === "Student"}
+        formik={formik}
       />
     </>
   );

--- a/src/components/user/userSubmission/CountrySelect.tsx
+++ b/src/components/user/userSubmission/CountrySelect.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { MenuItem, Paper } from "@mui/material";
 import Autocomplete from "@mui/material/Autocomplete";
-import { FormikContextType, useFormikContext } from "formik";
+import { FormikProps } from "formik";
 import { SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -56,15 +56,14 @@ const StyledPaper = styled(Paper)`
   }
 `;
 
-const CountrySelect = ({ required = false }: { required?: boolean }) => {
+interface CountrySelectProps {
+  required?: boolean;
+  formik: FormikProps<UserInfo>;
+}
+
+const CountrySelect = ({ required = false, formik }: CountrySelectProps) => {
   const { t } = useTranslation();
-  const {
-    values,
-    errors,
-    touched,
-    setValues,
-    handleBlur,
-  }: FormikContextType<UserInfo> = useFormikContext();
+  const { values, errors, touched, setValues, handleBlur } = formik;
 
   const handleChangeCountry = (
     e: SyntheticEvent<Element>,

--- a/src/components/user/userSubmission/CountrySelect.tsx
+++ b/src/components/user/userSubmission/CountrySelect.tsx
@@ -17,7 +17,7 @@ import {
   StyledTextField,
 } from "@/components/user/userSubmission/FormItems";
 
-const StyledDiv = styled.div`
+const StyledCountrySelectBox = styled.div`
   margin-top: 8px;
   margin-bottom: 4px;
 `;
@@ -76,7 +76,7 @@ const CountrySelect = ({ required = false, formik }: CountrySelectProps) => {
 
   return (
     <>
-      <StyledDiv>
+      <StyledCountrySelectBox>
         <Autocomplete
           defaultValue={values.countryCode}
           options={countries.sort((a, b) => {
@@ -133,7 +133,7 @@ const CountrySelect = ({ required = false, formik }: CountrySelectProps) => {
           PaperComponent={(props) => <StyledPaper {...props} />}
           onChange={(e, option) => option && handleChangeCountry(e, option)}
         />
-      </StyledDiv>
+      </StyledCountrySelectBox>
       {errors.countryCode && touched.countryCode && (
         <StyledErrorMessage>
           {Icons["error"]}

--- a/src/components/user/userSubmission/FormItems.tsx
+++ b/src/components/user/userSubmission/FormItems.tsx
@@ -8,7 +8,7 @@ import {
   Stepper,
   TextField,
 } from "@mui/material";
-import { FormikContextType, useFormikContext } from "formik";
+import { FormikProps } from "formik";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -177,10 +177,15 @@ const StyledIconButton = styled(IconButton)`
   padding: 0;
 `;
 
-const AddressCheckbox = ({ name }: { name: string }) => {
+const AddressCheckbox = ({
+  name,
+  formik,
+}: {
+  name: string;
+  formik: FormikProps<UserInfo>;
+}) => {
   const { t } = useTranslation();
-  const { values, handleBlur, handleChange }: FormikContextType<UserInfo> =
-    useFormikContext();
+  const { values, handleBlur, handleChange } = formik;
 
   return (
     <StyledFormControlLabel

--- a/src/components/user/userSubmission/FormItems.tsx
+++ b/src/components/user/userSubmission/FormItems.tsx
@@ -235,17 +235,6 @@ const UserInput = ({
         type={type}
         margin="dense"
         fullWidth
-        InputProps={
-          {
-            // endAdornment: (
-            //   <InputAdornment position="end">
-            //     {!errors[name] && touched[name] && (
-            //       <>{Icons["select"]}</>
-            //     )}
-            //   </InputAdornment>
-            // ),
-          }
-        }
         disabled={disable}
       />
       {errors[name] && touched[name] ? (

--- a/src/components/user/userSubmission/FormItems.tsx
+++ b/src/components/user/userSubmission/FormItems.tsx
@@ -196,27 +196,25 @@ const AddressCheckbox = ({ name }: { name: string }) => {
   );
 };
 
+interface UserInputProps {
+  label: string;
+  name: string;
+  type?: string;
+  disable?: boolean;
+  required?: boolean;
+  formik: FormikProps<UserInfo>;
+}
+
 const UserInput = ({
   label,
   name,
   type = "text",
   disable = false,
   required = false,
-}: {
-  label: string;
-  name: string;
-  type?: string;
-  disable?: boolean;
-  required?: boolean;
-}) => {
+  formik,
+}: UserInputProps) => {
   const { t } = useTranslation();
-  const {
-    values,
-    errors,
-    touched,
-    handleBlur,
-    handleChange,
-  }: FormikContextType<UserInfo> = useFormikContext();
+  const { values, errors, touched, handleBlur, handleChange } = formik;
 
   return (
     <>
@@ -255,27 +253,23 @@ const UserInput = ({
   );
 };
 
+interface UserSelectProps {
+  label: string;
+  name: string;
+  items: string[];
+  required?: boolean;
+  formik: FormikProps<UserInfo>;
+}
+
 const UserSelect = ({
   label,
   name,
   items,
-
   required = false,
-}: {
-  label: string;
-  name: string;
-  items: string[];
-
-  required?: boolean;
-}) => {
+  formik,
+}: UserSelectProps) => {
   const { t } = useTranslation();
-  const {
-    values,
-    errors,
-    touched,
-    handleBlur,
-    handleChange,
-  }: FormikContextType<UserInfo> = useFormikContext();
+  const { values, errors, touched, handleBlur, handleChange } = formik;
   const [v, setV] = useState("");
   useEffect(() => setV(values[name]), [values[name]]);
 

--- a/src/components/user/userSubmission/ShippingAddress.tsx
+++ b/src/components/user/userSubmission/ShippingAddress.tsx
@@ -38,16 +38,19 @@ const ShippingAddress = ({ formik }: { formik: FormikProps<UserInfo> }) => {
         label={t("Postal Code")}
         name="spPostalCode"
         disable={values.isSameAddress}
+        formik={formik}
       />
       <UserInput
         label={t("Address")}
         name="spAddress"
         disable={values.isSameAddress}
+        formik={formik}
       />
       <UserInput
         label={t("Detail Address")}
         name="spDetailAddress"
         disable={values.isSameAddress}
+        formik={formik}
       />
     </>
   );

--- a/src/components/user/userSubmission/UserBasicInfo.tsx
+++ b/src/components/user/userSubmission/UserBasicInfo.tsx
@@ -2,7 +2,7 @@ import { FormikProps } from "formik";
 import { useTranslation } from "react-i18next";
 
 import { UserInfo } from "@/components/const";
-import { business } from "@/components/user/userSubmission/const";
+import { businessList } from "@/components/user/userSubmission/const";
 import CountrySelect from "@/components/user/userSubmission/CountrySelect";
 import {
   UserInput,
@@ -29,7 +29,7 @@ const UserBasicInfo = ({ formik }: { formik: FormikProps<UserInfo> }) => {
       <UserSelect
         label={t("Business Type")}
         name="businessType"
-        items={business}
+        items={businessList}
         required={true}
         formik={formik}
       />

--- a/src/components/user/userSubmission/UserBasicInfo.tsx
+++ b/src/components/user/userSubmission/UserBasicInfo.tsx
@@ -1,3 +1,4 @@
+import { FormikProps } from "formik";
 import { useTranslation } from "react-i18next";
 
 import { UserInfo } from "@/components/const";
@@ -8,32 +9,50 @@ import {
   UserSelect,
 } from "@/components/user/userSubmission/FormItems";
 
-interface UserBasicInfoProps {
-  values: UserInfo;
-}
-
-const UserBasicInfo = ({ values }: UserBasicInfoProps) => {
+const UserBasicInfo = ({ formik }: { formik: FormikProps<UserInfo> }) => {
   const { t } = useTranslation();
 
   return (
     <>
-      <UserInput label={t("Name")} name="name" required={true} />
-      <UserInput label={t("Company Name")} name="companyName" required={true} />
+      <UserInput
+        label={t("Name")}
+        name="name"
+        required={true}
+        formik={formik}
+      />
+      <UserInput
+        label={t("Company Name")}
+        name="companyName"
+        required={true}
+        formik={formik}
+      />
       <UserSelect
         label={t("Business Type")}
         name="businessType"
         items={business}
         required={true}
+        formik={formik}
       />
-      <CountrySelect required={true} />
-      <UserInput label={t("Phone Number")} name="phoneNumber" required={true} />
-      {values.countryCode.label === "China" && (
-        <UserInput label="WeChat ID" name="weChatId" required={true} />
+      <CountrySelect required={true} formik={formik} />
+      <UserInput
+        label={t("Phone Number")}
+        name="phoneNumber"
+        required={true}
+        formik={formik}
+      />
+      {formik.values.countryCode.label === "China" && (
+        <UserInput
+          label="WeChat ID"
+          name="weChatId"
+          required={true}
+          formik={formik}
+        />
       )}
       <UserInput
         label={t("Email")}
         name="email"
-        required={values.countryCode.label !== "China"}
+        required={formik.values.countryCode.label !== "China"}
+        formik={formik}
       />
     </>
   );

--- a/src/components/user/userSubmission/UserForm.tsx
+++ b/src/components/user/userSubmission/UserForm.tsx
@@ -73,12 +73,12 @@ const UserForm = forwardRef<UserFormHandle, UserFormProps>(
                 <AddressBox>
                   <StepLabel>{t(step.label)}</StepLabel>
                   {values.businessType !== "Student" && (
-                    <AddressCheckbox name="isSameAddress" />
+                    <AddressCheckbox name="isSameAddress" formik={formik} />
                   )}
                 </AddressBox>
               )}
               <StepContent>
-                {index === 0 && <UserBasicInfo values={values} />}
+                {index === 0 && <UserBasicInfo formik={formik} />}
                 {index === 1 && <CompanyAddress formik={formik} />}
                 {index === 2 && <ShippingAddress formik={formik} />}
               </StepContent>

--- a/src/components/user/userSubmission/const.ts
+++ b/src/components/user/userSubmission/const.ts
@@ -12,7 +12,9 @@ export const steps: UserFormStep[] = [
   { label: "Shipping Address" },
 ];
 
-export const business: string[] = [
+type Business = "Trading" | "Wholesaler" | "Converter" | "Brand" | "Student";
+
+export const businessList: Business[] = [
   "Trading",
   "Wholesaler",
   "Converter",

--- a/src/components/user/userSubmission/const.ts
+++ b/src/components/user/userSubmission/const.ts
@@ -1,12 +1,18 @@
 import { UserInfo } from "@/components/const";
+import { CountryType } from "@/components/user/userSubmission/countries";
+import { SelectedInfoList } from "@/recoil/user/atoms/selectedInfoListState";
 
-export const steps = [
+interface UserFormStep {
+  label: string;
+}
+
+export const steps: UserFormStep[] = [
   { label: "Orderer" },
   { label: "Company Address" },
   { label: "Shipping Address" },
 ];
 
-export const business = [
+export const business: string[] = [
   "Trading",
   "Wholesaler",
   "Converter",
@@ -35,3 +41,27 @@ export const userInfoInitialValues: UserInfo = {
   isSameAddress: false,
   productLengthUnit: "METER",
 };
+
+export interface FormatShippingAddressProps {
+  isSameAddress: boolean;
+  coPostalCode: string;
+  coAddress: string;
+  coDetailAddress: string;
+  spPostalCode: string;
+  spAddress: string;
+  spDetailAddress: string;
+}
+
+export interface FormatContactInfoProps {
+  countryCode: CountryType;
+  phoneNumber: string;
+  email: string;
+  weChatId: string;
+}
+
+export interface FormatSubmitUserBodyProps {
+  form: UserInfo;
+  submissionTime: string;
+  language: string;
+  selectedInfoList: SelectedInfoList;
+}

--- a/src/components/user/userSubmission/utils.ts
+++ b/src/components/user/userSubmission/utils.ts
@@ -1,21 +1,30 @@
-import { UserInfo } from "@/components/const";
+import {
+  FormatContactInfoProps,
+  FormatShippingAddressProps,
+  FormatSubmitUserBodyProps,
+} from "@/components/user/userSubmission/const";
 import { SelectedInfoList } from "@/recoil/user/atoms/selectedInfoListState";
 
-const formatShippingAddress = (
+const formatShippingAddress = ({
   isSameAddress,
   coPostalCode,
   coAddress,
   coDetailAddress,
   spPostalCode,
   spAddress,
-  spDetailAddress
-) => ({
+  spDetailAddress,
+}: FormatShippingAddressProps) => ({
   postalCode: isSameAddress ? coPostalCode : spPostalCode,
   address: isSameAddress ? coAddress : spAddress,
   detailAddress: isSameAddress ? coDetailAddress : spDetailAddress,
 });
 
-const formatContactInfo = (countryCode, phoneNumber, email, weChatId) => ({
+const formatContactInfo = ({
+  countryCode,
+  phoneNumber,
+  email,
+  weChatId,
+}: FormatContactInfoProps) => ({
   phoneNumber: {
     countryCode: `+${countryCode.phone}`,
     number: phoneNumber,
@@ -36,12 +45,12 @@ const formatHopeProducts = (selectedInfoList: SelectedInfoList) =>
       }),
   }));
 
-export const formatSubmitUserBody = (
-  form: UserInfo,
-  submissionTime: string,
-  language: string,
-  selectedInfoList: SelectedInfoList
-) => {
+export const formatSubmitUserBody = ({
+  form,
+  submissionTime,
+  language,
+  selectedInfoList,
+}: FormatSubmitUserBodyProps) => {
   const {
     name,
     companyName,
@@ -68,21 +77,26 @@ export const formatSubmitUserBody = (
       name,
       companyName,
       businessType,
-      contactInfo: formatContactInfo(countryCode, phoneNumber, email, weChatId),
+      contactInfo: formatContactInfo({
+        countryCode,
+        phoneNumber,
+        email,
+        weChatId,
+      }),
       companyAddress: {
         postalCode: coPostalCode,
         address: coAddress,
         detailAddress: coDetailAddress,
       },
-      shippingAddress: formatShippingAddress(
+      shippingAddress: formatShippingAddress({
         isSameAddress,
         coPostalCode,
         coAddress,
         coDetailAddress,
         spPostalCode,
         spAddress,
-        spDetailAddress
-      ),
+        spDetailAddress,
+      }),
     },
     language: language,
   });


### PR DESCRIPTION
<!-- 제목 뒤에 # 이슈번호 붙여주세요. -->

## 개요

Info 페이지 내부에 타입 지정이 누락된 부분이 있어 타입을 지정하였습니다.
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## 변경 사항

- `/userSubmission` 내부 컴포넌트 props 타입, 함수 props 타입, 변수 타입 지정
- `CountrySelect`의 emotion 컴포넌트에 컨벤션 적용 (`StyledBox` → `StyeldCountrySelectBox`)
- formik prop이 적용되지 않은 부분에 formik prop 적용

## To Reviewers

- 사용자 input에서 유효성 통과 시 띄우던 체크 아이콘을 더이상 사용하지 않음에 따라 주석된 코드를 삭제하였습니다.