### PR TITLE
useOverlay exit 미사용으로 인한 메모리 누수 해결 #288

### DIFF
--- a/src/components/common/Confirm.tsx
+++ b/src/components/common/Confirm.tsx
@@ -1,26 +1,48 @@
 import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
 
+import { OverlayControl } from "@/const";
+
 const Confirm = ({
-  isConfirmOpen,
-  onClose,
-  onConfirm,
+  overlayControl,
   content,
+  onClose = () => {},
+  onConfirm = () => {},
   confirmText,
   cancelText,
 }: {
-  isConfirmOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
+  overlayControl: OverlayControl;
   content: string;
+  onClose?: () => void | Promise<void>;
+  onConfirm?: () => void | Promise<void>;
   confirmText?: string;
   cancelText?: string;
 }) => {
   return (
-    <Dialog open={isConfirmOpen} onClose={onClose}>
+    <Dialog
+      open={overlayControl.isOpen}
+      onClose={async () => {
+        await onClose();
+        overlayControl.exit();
+      }}
+    >
       <DialogContent>{content}</DialogContent>
       <DialogActions>
-        <Button onClick={onConfirm}>{confirmText ?? "예"}</Button>
-        <Button onClick={onClose}>{cancelText ?? "취소"}</Button>
+        <Button
+          onClick={async () => {
+            await onConfirm();
+            overlayControl.exit();
+          }}
+        >
+          {confirmText ?? "예"}
+        </Button>
+        <Button
+          onClick={async () => {
+            await onClose();
+            overlayControl.exit();
+          }}
+        >
+          {cancelText ?? "취소"}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/common/MessageDialog.tsx
+++ b/src/components/common/MessageDialog.tsx
@@ -8,6 +8,8 @@ import {
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
+import { OverlayControl } from "@/const";
+
 interface StyledMessageDialogProps {
   customStyle?: string;
 }
@@ -21,22 +23,25 @@ const StyledMessageDialog = styled(Dialog, {
 `;
 
 const MessageDialog = ({
-  isDialogOpen,
-  onDialogClose,
+  overlayControl,
   messageList,
+  onDialogClose = () => {},
   customStyle = "",
 }: {
-  isDialogOpen: boolean;
-  onDialogClose: () => void;
+  overlayControl: OverlayControl;
   messageList: string[];
+  onDialogClose?: () => void | Promise<void>;
   customStyle?: string;
 }) => {
   const { t } = useTranslation();
 
   return (
     <StyledMessageDialog
-      open={isDialogOpen}
-      onClose={onDialogClose}
+      open={overlayControl.isOpen}
+      onClose={async () => {
+        await onDialogClose();
+        overlayControl.exit();
+      }}
       customStyle={customStyle}
     >
       <DialogContent>
@@ -45,7 +50,14 @@ const MessageDialog = ({
         ))}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onDialogClose} color="primary" autoFocus>
+        <Button
+          onClick={async () => {
+            await onDialogClose();
+            overlayControl.exit();
+          }}
+          color="primary"
+          autoFocus
+        >
           {t("Confirm")}
         </Button>
       </DialogActions>

--- a/src/components/manager/Dashboard.tsx
+++ b/src/components/manager/Dashboard.tsx
@@ -35,10 +35,9 @@ const Dashboard = () => {
       const folderList = await getFolderList();
       setFolderList(folderList);
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["폴더 불러오기 실패"]}
         />
       ));

--- a/src/components/manager/Menu.tsx
+++ b/src/components/manager/Menu.tsx
@@ -105,10 +105,9 @@ const NestedListItem = ({
                 <EditIcon
                   onClick={(e) => {
                     e.stopPropagation();
-                    overlay.open(({ isOpen, close }) => (
+                    overlay.open((control) => (
                       <FolderActionModal
-                        isModalOpen={isOpen}
-                        onClose={close}
+                        overlayControl={control}
                         folder={folder}
                         onFolderListUpdate={onFolderListUpdate}
                         onFolderDelete={onFolderDelete}
@@ -123,10 +122,9 @@ const NestedListItem = ({
         <ListItem>
           <ListItemButton
             onClick={() => {
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <FolderCreationModal
-                  isModalOpen={isOpen}
-                  onClose={close}
+                  overlayControl={control}
                   type={folderList[0].type}
                   onFolderListUpdate={onFolderListUpdate}
                 />

--- a/src/components/manager/folder/DataFolderReassignModal.tsx
+++ b/src/components/manager/folder/DataFolderReassignModal.tsx
@@ -11,7 +11,7 @@ import { Field, Form, Formik } from "formik";
 import * as Yup from "yup";
 
 import MessageDialog from "@/components/common/MessageDialog";
-import { Folder, Product, User } from "@/const";
+import { Folder, OverlayControl, Product, User } from "@/const";
 import { reassignFolder } from "@/services/folders";
 
 const StyledModalContainer = styled.div`
@@ -29,15 +29,13 @@ const folderSelectionSchema = Yup.object({
 });
 
 const DataFolderReassignModal = ({
-  isModalOpen,
-  onModalClose,
+  overlayControl,
   selectedDataList,
   folder,
   folderList,
   onReassignComplete,
 }: {
-  isModalOpen: boolean;
-  onModalClose: () => void;
+  overlayControl: OverlayControl;
   selectedDataList: User[] | Product[];
   folder: Folder;
   folderList: Folder[];
@@ -46,7 +44,7 @@ const DataFolderReassignModal = ({
   const overlay = useOverlay();
 
   return (
-    <Modal open={isModalOpen} onClose={onModalClose}>
+    <Modal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <h3>{folder.type}</h3>
         <Formik
@@ -58,12 +56,11 @@ const DataFolderReassignModal = ({
             try {
               await reassignFolder(selectedDataList, values.folderId);
               onReassignComplete && (await onReassignComplete());
-              onModalClose();
+              overlayControl.exit();
             } catch {
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <MessageDialog
-                  isDialogOpen={isOpen}
-                  onDialogClose={close}
+                  overlayControl={control}
                   messageList={["폴더 이동 실패"]}
                 />
               ));
@@ -100,7 +97,7 @@ const DataFolderReassignModal = ({
                 <Button type="submit" disabled={isSubmitting}>
                   확인
                 </Button>
-                <Button onClick={onModalClose}>닫기</Button>
+                <Button onClick={overlayControl.exit}>닫기</Button>
               </DialogActions>
             </Form>
           )}

--- a/src/components/manager/folder/FolderActionModal.tsx
+++ b/src/components/manager/folder/FolderActionModal.tsx
@@ -106,8 +106,10 @@ const FolderActionModal = ({
                     overlay.open((control) => (
                       <Confirm
                         overlayControl={control}
+                        onClose={overlayControl.exit}
                         onConfirm={async () => {
                           await deletionFormik.submitForm();
+                          overlayControl.exit();
                         }}
                         content={
                           "폴더 삭제 시 내부 데이터는 휴지통으로 이동합니다. 삭제하시겠습니까?"

--- a/src/components/manager/folder/FolderCreationModal.tsx
+++ b/src/components/manager/folder/FolderCreationModal.tsx
@@ -6,6 +6,7 @@ import * as Yup from "yup";
 
 import { postFolder } from "@/api/folders";
 import MessageDialog from "@/components/common/MessageDialog";
+import { OverlayControl } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -34,20 +35,18 @@ const creationValidationSchema = Yup.object({
 });
 
 const FolderCreationModal = ({
-  isModalOpen,
-  onClose,
+  overlayControl,
   type,
   onFolderListUpdate,
 }: {
-  isModalOpen: boolean;
-  onClose: () => void;
+  overlayControl: OverlayControl;
   type: "user" | "product";
   onFolderListUpdate: () => void;
 }) => {
   const overlay = useOverlay();
 
   return (
-    <Modal open={isModalOpen} onClose={onClose}>
+    <Modal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <h3>{type} 폴더 생성</h3>
         <Formik
@@ -60,12 +59,11 @@ const FolderCreationModal = ({
             try {
               await postFolder(JSON.stringify(values));
               onFolderListUpdate();
-              onClose();
+              overlayControl.exit();
             } catch {
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <MessageDialog
-                  isDialogOpen={isOpen}
-                  onDialogClose={close}
+                  overlayControl={control}
                   messageList={["폴더 생성 실패"]}
                 />
               ));
@@ -88,7 +86,7 @@ const FolderCreationModal = ({
                 <Button type="submit" disabled={isSubmitting}>
                   생성
                 </Button>
-                <Button onClick={onClose}>닫기</Button>
+                <Button onClick={overlayControl.exit}>닫기</Button>
               </DialogActions>
             </StyledForm>
           )}

--- a/src/components/manager/product/ExcelProductCreateModal.tsx
+++ b/src/components/manager/product/ExcelProductCreateModal.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/manager/product/const";
 import ExcelProductTableModal from "@/components/manager/product/ExcelProductTableModal";
 import { handleExcelFileProductList } from "@/components/manager/product/util";
-import { Folder, Product } from "@/const";
+import { Folder, OverlayControl, Product } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -43,16 +43,14 @@ const transformProductExcelListToSubmitForm = (
 };
 
 const ExcelProductCreateModal = ({
+  overlayControl,
   folder,
   productList,
-  isModalOpen,
-  onModalClose,
   onProductListCreate,
 }: {
+  overlayControl: OverlayControl;
   folder: Folder;
   productList: Product[];
-  isModalOpen: boolean;
-  onModalClose: () => void;
   onProductListCreate: () => void;
 }) => {
   const [isFileUploaded, setIsFileUploaded] = useState(false);
@@ -91,21 +89,22 @@ const ExcelProductCreateModal = ({
         transformProductExcelListToSubmitForm(newProductList, folder.id)
       );
       onProductListCreate();
+      overlayControl.exit();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
+          onDialogClose={() => {
+            overlayControl.exit();
+          }}
           messageList={["제품 생성 실패"]}
         />
       ));
-    } finally {
-      onModalClose();
     }
   };
 
   return (
-    <Modal open={isModalOpen} onClose={onModalClose}>
+    <Modal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <h3>엑셀 파일 추출로 제품 생성</h3>
         <FileUploader
@@ -129,11 +128,10 @@ const ExcelProductCreateModal = ({
               <Button
                 variant="text"
                 onClick={() => {
-                  overlay.open(({ isOpen, close }) => (
+                  overlay.open((control) => (
                     <ExcelProductTableModal
+                      overlayControl={control}
                       productList={newProductList}
-                      isModalOpen={isOpen}
-                      onModalClose={close}
                     />
                   ));
                 }}
@@ -146,11 +144,10 @@ const ExcelProductCreateModal = ({
               <Button
                 variant="text"
                 onClick={() => {
-                  overlay.open(({ isOpen, close }) => (
+                  overlay.open((control) => (
                     <ExcelProductTableModal
+                      overlayControl={control}
                       productList={existingProductList}
-                      isModalOpen={isOpen}
-                      onModalClose={close}
                     />
                   ));
                 }}
@@ -163,11 +160,10 @@ const ExcelProductCreateModal = ({
               <Button
                 variant="text"
                 onClick={() => {
-                  overlay.open(({ isOpen, close }) => (
+                  overlay.open((control) => (
                     <ExcelProductTableModal
+                      overlayControl={control}
                       productList={errorProductList}
-                      isModalOpen={isOpen}
-                      onModalClose={close}
                     />
                   ));
                 }}
@@ -179,7 +175,7 @@ const ExcelProductCreateModal = ({
         )}
         <DialogActions>
           <Button onClick={handleProductListCreate}>제품 생성하기</Button>
-          <Button onClick={onModalClose}>취소</Button>
+          <Button onClick={overlayControl.exit}>취소</Button>
         </DialogActions>
       </StyledModalContainer>
     </Modal>

--- a/src/components/manager/product/ExcelProductTableModal.tsx
+++ b/src/components/manager/product/ExcelProductTableModal.tsx
@@ -6,6 +6,7 @@ import {
   ErrorProductExcel,
   ProductExcel,
 } from "@/components/manager/product/const";
+import { OverlayControl } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -31,13 +32,11 @@ const columns: GridColDef[] = [
 ];
 
 const ExcelProductTableModal = ({
+  overlayControl,
   productList,
-  isModalOpen,
-  onModalClose,
 }: {
+  overlayControl: OverlayControl;
   productList: ProductExcel[] | ErrorProductExcel[];
-  isModalOpen: boolean;
-  onModalClose: () => void;
 }) => {
   const tableRows = productList.map((p: ProductExcel | ErrorProductExcel) => {
     const { __rowNum__, ...rest } = p;
@@ -48,7 +47,7 @@ const ExcelProductTableModal = ({
   });
 
   return (
-    <Modal open={isModalOpen} onClose={onModalClose}>
+    <Modal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <DataGrid
           rows={tableRows}

--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -56,10 +56,9 @@ const ProductBoard = ({
       const productList = await getProductList();
       setProductList(productList);
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 가져오기 실패"]}
         />
       ));
@@ -76,10 +75,9 @@ const ProductBoard = ({
       );
       await handleProductListUpdate();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 복구 실패"]}
         />
       ));
@@ -96,10 +94,9 @@ const ProductBoard = ({
       );
       await handleProductListUpdate();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 삭제 실패"]}
         />
       ));
@@ -111,10 +108,9 @@ const ProductBoard = ({
       await deleteProductList(selectedProductList);
       await handleProductListUpdate();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 영구 삭제 실패"]}
         />
       ));
@@ -161,10 +157,9 @@ const ProductBoard = ({
         }
         downloadLink.click();
       } catch (e) {
-        overlay.open(({ isOpen, close }) => (
+        overlay.open((control) => (
           <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
+            overlayControl={control}
             messageList={[e?.message ?? "QR code 생성 실패"]}
           />
         ));
@@ -174,10 +169,9 @@ const ProductBoard = ({
 
   const handleProductFolderReassign = () => {
     if (selectedProductList.length > 0) {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <DataFolderReassignModal
-          isModalOpen={isOpen}
-          onModalClose={close}
+          overlayControl={control}
           selectedDataList={filteredProductList.filter((f) =>
             selectedProductList.find((productId) => f.productId === productId)
           )}
@@ -215,11 +209,10 @@ const ProductBoard = ({
               </Button>
               <Button
                 onClick={() => {
-                  overlay.open(({ isOpen, close }) => (
+                  overlay.open((control) => (
                     <ProductCreateModal
+                      overlayControl={control}
                       folder={folder}
-                      isModalOpen={isOpen}
-                      onModalClose={close}
                       onProductCreate={handleProductListUpdate}
                     />
                   ));
@@ -229,12 +222,11 @@ const ProductBoard = ({
               </Button>
               <Button
                 onClick={() => {
-                  overlay.open(({ isOpen, close }) => (
+                  overlay.open((control) => (
                     <ExcelProductCreateModal
+                      overlayControl={control}
                       folder={folder}
                       productList={productList}
-                      isModalOpen={isOpen}
-                      onModalClose={close}
                       onProductListCreate={handleProductListUpdate}
                     />
                   ));

--- a/src/components/manager/product/ProductCreateModal.tsx
+++ b/src/components/manager/product/ProductCreateModal.tsx
@@ -17,17 +17,15 @@ import {
   productCreationInitialValues,
   productCreationSchema,
 } from "@/components/manager/product/const";
-import { Folder } from "@/const";
+import { Folder, OverlayControl } from "@/const";
 
 const ProductCreateModal = ({
+  overlayControl,
   folder,
-  isModalOpen,
-  onModalClose,
   onProductCreate,
 }: {
+  overlayControl: OverlayControl;
   folder: Folder;
-  isModalOpen: boolean;
-  onModalClose: () => void;
   onProductCreate: () => void;
 }) => {
   const overlay = useOverlay();
@@ -63,12 +61,8 @@ const ProductCreateModal = ({
         resetForm();
         onProductCreate();
       } catch (e) {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={[e.message]}
-          />
+        overlay.open((control) => (
+          <MessageDialog overlayControl={control} messageList={[e.message]} />
         ));
       }
     },
@@ -112,7 +106,7 @@ const ProductCreateModal = ({
   }, [colors.length]);
 
   return (
-    <StyledModal open={isModalOpen} onClose={onModalClose}>
+    <StyledModal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <ProductAddModal>
         <h2>Add</h2>
         <ProductInput label="Product ID" name="productId" formik={formik} />
@@ -161,7 +155,7 @@ const ProductCreateModal = ({
           >
             Confirm
           </Button>
-          <Button onClick={onModalClose}>Cancel</Button>
+          <Button onClick={overlayControl.exit}>Cancel</Button>
         </StyledFlexDiv>
       </ProductAddModal>
     </StyledModal>

--- a/src/components/manager/product/ProductDetailModal.int.test.tsx
+++ b/src/components/manager/product/ProductDetailModal.int.test.tsx
@@ -10,13 +10,17 @@ describe("ProductDetailModal", () => {
   it("초기 렌더링 확인", async () => {
     // Given
     const modalProductData = mockProductList[0];
+    const control = {
+      isOpen: true,
+      close: jest.fn(),
+      exit: jest.fn(),
+    };
 
     // When
     render(
       <OverlayProvider>
         <ProductDetailModal
-          isModalOpen={true}
-          onModalClose={jest.fn()}
+          overlayControl={control}
           modalProductData={modalProductData}
         />
       </OverlayProvider>
@@ -31,13 +35,17 @@ describe("ProductDetailModal", () => {
   it("수정 누를 시 edit 모드로 변경", async () => {
     // Given
     const modalProductData = mockProductList[0];
+    const control = {
+      isOpen: true,
+      close: jest.fn(),
+      exit: jest.fn(),
+    };
 
     // When
     render(
       <OverlayProvider>
         <ProductDetailModal
-          isModalOpen={true}
-          onModalClose={jest.fn()}
+          overlayControl={control}
           modalProductData={modalProductData}
         />
       </OverlayProvider>

--- a/src/components/manager/product/ProductDetailModal.tsx
+++ b/src/components/manager/product/ProductDetailModal.tsx
@@ -7,7 +7,7 @@ import ImageWithFallback from "@/components/common/ImageWithFallback";
 import { StyledModal } from "@/components/manager/DashboardItems";
 import { productDetailColumns } from "@/components/manager/product/const";
 import ProductEditModal from "@/components/manager/product/ProductEditModal";
-import { Product } from "@/const";
+import { OverlayControl, Product } from "@/const";
 
 const StyledDetailModalContainer = styled.div`
   position: relative;
@@ -59,12 +59,10 @@ const StyledDetailModalContainer = styled.div`
 `;
 
 const ProductDetailModal = ({
-  isModalOpen,
-  onModalClose,
+  overlayControl,
   modalProductData,
 }: {
-  isModalOpen: boolean;
-  onModalClose: () => void;
+  overlayControl: OverlayControl;
   modalProductData: Product;
 }) => {
   const { productId, image, composition, weightGPerM2, widthInch, colors } =
@@ -79,8 +77,8 @@ const ProductDetailModal = ({
 
   return (
     <StyledModal
-      open={isModalOpen}
-      onClose={onModalClose}
+      open={overlayControl.isOpen}
+      onClose={overlayControl.exit}
       data-testid={"product-detail-modal"}
     >
       <StyledDetailModalContainer>
@@ -118,20 +116,19 @@ const ProductDetailModal = ({
         <div className="buttonContainer">
           <Button
             onClick={() => {
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <ProductEditModal
+                  overlayControl={control}
                   product={modalProductData}
-                  isModalOpen={isOpen}
-                  onModalClose={close}
                 />
               ));
-              onModalClose();
+              overlayControl.close();
             }}
             data-testid={"product-detail-open-edit-modal-button"}
           >
             수정
           </Button>
-          <Button onClick={onModalClose}>닫기</Button>
+          <Button onClick={overlayControl.exit}>닫기</Button>
         </div>
       </StyledDetailModalContainer>
     </StyledModal>

--- a/src/components/manager/product/ProductEditModal.tsx
+++ b/src/components/manager/product/ProductEditModal.tsx
@@ -18,16 +18,14 @@ import {
   productEditionSchema,
 } from "@/components/manager/product/const";
 import ProductDetailModal from "@/components/manager/product/ProductDetailModal";
-import { Product } from "@/const";
+import { OverlayControl, Product } from "@/const";
 
 const ProductEditModal = ({
+  overlayControl,
   product,
-  isModalOpen,
-  onModalClose,
 }: {
+  overlayControl: OverlayControl;
   product: Product;
-  isModalOpen: boolean;
-  onModalClose: () => void;
 }) => {
   const overlay = useOverlay();
   const formik = useFormik({
@@ -61,21 +59,13 @@ const ProductEditModal = ({
 
       try {
         const res = await putProduct(formData, product.productId);
-        overlay.open(({ isOpen, close }) => (
-          <ProductDetailModal
-            modalProductData={res}
-            isModalOpen={isOpen}
-            onModalClose={close}
-          />
+        overlay.open((control) => (
+          <ProductDetailModal overlayControl={control} modalProductData={res} />
         ));
-        onModalClose();
+        overlayControl.close();
       } catch (e) {
-        overlay.open(({ isOpen, close }) => (
-          <MessageDialog
-            isDialogOpen={isOpen}
-            onDialogClose={close}
-            messageList={[e.message]}
-          />
+        overlay.open((control) => (
+          <MessageDialog overlayControl={control} messageList={[e.message]} />
         ));
       }
     },
@@ -132,7 +122,7 @@ const ProductEditModal = ({
   }, [product]);
 
   return (
-    <StyledModal open={isModalOpen} onClose={onModalClose}>
+    <StyledModal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <ProductAddModal data-testid={"product-edit-modal"}>
         <h2>Edit</h2>
         <TextField
@@ -199,14 +189,13 @@ const ProductEditModal = ({
           </Button>
           <Button
             onClick={() => {
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <ProductDetailModal
+                  overlayControl={control}
                   modalProductData={product}
-                  isModalOpen={isOpen}
-                  onModalClose={close}
                 />
               ));
-              onModalClose();
+              overlayControl.close();
             }}
           >
             Cancel

--- a/src/components/manager/product/ProductTable.tsx
+++ b/src/components/manager/product/ProductTable.tsx
@@ -65,10 +65,9 @@ const ProductTable = ({
         onCellClick={(cell: GridCellParams<ProductTableRow>, e) => {
           if (cell.field !== "__check__") {
             e.stopPropagation();
-            overlay.open(({ isOpen, close }) => (
+            overlay.open((control) => (
               <ProductDetailModal
-                isModalOpen={isOpen}
-                onModalClose={close}
+                overlayControl={control}
                 modalProductData={cell.row.__product__}
               />
             ));

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -65,10 +65,9 @@ const UserBoard = ({
       const userList = await getUserList();
       setUserList(userList);
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 가져오기 실패"]}
         />
       ));
@@ -85,10 +84,9 @@ const UserBoard = ({
       );
       await updateUserList();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 복구 실패"]}
         />
       ));
@@ -105,10 +103,9 @@ const UserBoard = ({
       );
       await updateUserList();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 삭제 실패"]}
         />
       ));
@@ -120,10 +117,9 @@ const UserBoard = ({
       await deleteUserList(selectedUserList);
       await updateUserList();
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["데이터 영구 삭제 실패"]}
         />
       ));
@@ -132,10 +128,9 @@ const UserBoard = ({
 
   const handleUserFolderReassign = () => {
     if (selectedUserList.length > 0) {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <DataFolderReassignModal
-          isModalOpen={isOpen}
-          onModalClose={close}
+          overlayControl={control}
           selectedDataList={filteredUserList.filter((f) =>
             selectedUserList.find((userId) => f.userId === userId)
           )}
@@ -238,10 +233,9 @@ const UserBoard = ({
       const productList = await getProductList();
       setProductList(productList);
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
+          overlayControl={control}
           messageList={["제품 목록 받아오기 실패"]}
         />
       ));
@@ -261,8 +255,8 @@ const UserBoard = ({
           {folder.id === USER_DEFAULT && (
             <Button
               onClick={() => {
-                overlay.open(({ isOpen, close }) => (
-                  <UserTextActionModal isModalOpen={isOpen} onClose={close} />
+                overlay.open((control) => (
+                  <UserTextActionModal overlayControl={control} />
                 ));
               }}
             >
@@ -283,10 +277,9 @@ const UserBoard = ({
               </Button>
               <Button
                 onClick={() => {
-                  overlay.open(({ isOpen, close }) => (
+                  overlay.open((control) => (
                     <UserCopyModal
-                      isModalOpen={isOpen}
-                      onModalClose={close}
+                      overlayControl={control}
                       selectedUserList={filteredUserList.filter((f) =>
                         selectedUserList.find((userId) => f.userId === userId)
                       )}

--- a/src/components/manager/user/UserCopyModal.tsx
+++ b/src/components/manager/user/UserCopyModal.tsx
@@ -13,7 +13,7 @@ import {
   optionsToCopyList,
   SelectedOptions,
 } from "@/components/manager/user/util";
-import { User } from "@/const";
+import { OverlayControl, User } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -48,12 +48,10 @@ const getTitleData = (option: string): string[] => {
 };
 
 const UserCopyModal = ({
-  isModalOpen,
-  onModalClose,
+  overlayControl,
   selectedUserList,
 }: {
-  isModalOpen: boolean;
-  onModalClose: () => void;
+  overlayControl: OverlayControl;
   selectedUserList: User[];
 }) => {
   const [isSelectedAllOptions, setIsSelectedAllOptions] =
@@ -159,7 +157,7 @@ const UserCopyModal = ({
   };
 
   return (
-    <Modal open={isModalOpen} onClose={onModalClose}>
+    <Modal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <h3>복사할 정보를 선택하세요.</h3>
         <FormControlLabel
@@ -198,7 +196,7 @@ const UserCopyModal = ({
           <Button onClick={handleUserCopy} ref={copyButtonRef}>
             복사
           </Button>
-          <Button onClick={onModalClose}>닫기</Button>
+          <Button onClick={overlayControl.exit}>닫기</Button>
         </DialogActions>
       </StyledModalContainer>
     </Modal>

--- a/src/components/manager/user/UserDetailModal.tsx
+++ b/src/components/manager/user/UserDetailModal.tsx
@@ -14,7 +14,7 @@ import {
   userMetadataColumns2,
 } from "@/components/manager/user/const";
 import { handleUserForOrder } from "@/components/manager/user/util";
-import { User } from "@/const";
+import { OverlayControl, User } from "@/const";
 
 const StyledModalContainer = styled.div`
   display: flex;
@@ -46,12 +46,10 @@ const StyledCopyButton = styled(Button)`
 `;
 
 const UserDetailModal = ({
-  isModalOpen,
-  onModalClose,
+  overlayControl,
   modalUserData,
 }: {
-  isModalOpen: boolean;
-  onModalClose: () => void;
+  overlayControl: OverlayControl;
   modalUserData: User;
 }) => {
   const {
@@ -87,7 +85,7 @@ const UserDetailModal = ({
   };
 
   return (
-    <StyledModal open={isModalOpen} onClose={onModalClose}>
+    <StyledModal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <h2>User Info</h2>
         <h4>Personal Info</h4>

--- a/src/components/manager/user/UserTable.tsx
+++ b/src/components/manager/user/UserTable.tsx
@@ -41,12 +41,8 @@ const UserTable = ({
     } catch (e) {
       old.__user__.remark1 = old.remark1;
       old.__user__.remark2 = old.remark2;
-      overlay.open(({ isOpen, close }) => (
-        <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
-          messageList={[e.message]}
-        />
+      overlay.open((control) => (
+        <MessageDialog overlayControl={control} messageList={[e.message]} />
       ));
       return old;
     }
@@ -76,10 +72,9 @@ const UserTable = ({
             cell.field !== "remark2"
           ) {
             e.stopPropagation();
-            overlay.open(({ isOpen, close }) => (
+            overlay.open((control) => (
               <UserDetailModal
-                isModalOpen={isOpen}
-                onModalClose={close}
+                overlayControl={control}
                 modalUserData={cell.row.__user__}
               />
             ));

--- a/src/components/manager/user/UserTextActionModal.tsx
+++ b/src/components/manager/user/UserTextActionModal.tsx
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 
 import { getText, putText } from "@/api/text";
 import MessageDialog from "@/components/common/MessageDialog";
+import { OverlayControl } from "@/const";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -33,11 +34,9 @@ const validationSchema = Yup.object({
 });
 
 const UserTextActionModal = ({
-  isModalOpen,
-  onClose,
+  overlayControl,
 }: {
-  isModalOpen: boolean;
-  onClose: () => void;
+  overlayControl: OverlayControl;
 }) => {
   const [initialText, setInitialText] = useState("");
   const overlay = useOverlay();
@@ -47,12 +46,11 @@ const UserTextActionModal = ({
       const { text } = await getText();
       setInitialText(text);
     } catch {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <MessageDialog
-          isDialogOpen={isOpen}
+          overlayControl={control}
           onDialogClose={() => {
-            close();
-            onClose();
+            overlayControl.exit();
           }}
           messageList={["기존 텍스트 불러오기 실패"]}
         />
@@ -61,13 +59,13 @@ const UserTextActionModal = ({
   };
 
   useEffect(() => {
-    if (isModalOpen) {
+    if (overlayControl.isOpen) {
       void handleTextUpdate();
     }
-  }, [isModalOpen]);
+  }, [overlayControl.isOpen]);
 
   return (
-    <Modal open={isModalOpen} onClose={onClose}>
+    <Modal open={overlayControl.isOpen} onClose={overlayControl.exit}>
       <StyledModalContainer>
         <h3>텍스트 설정</h3>
         <p>해당 텍스트는 앞으로의 유저 ID와 PDF 파일명에 적용됩니다.</p>
@@ -84,21 +82,19 @@ const UserTextActionModal = ({
           onSubmit={async (values, { setSubmitting }) => {
             try {
               await putText(JSON.stringify(values));
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <MessageDialog
-                  isDialogOpen={isOpen}
+                  overlayControl={control}
                   onDialogClose={() => {
-                    close();
-                    onClose();
+                    overlayControl.exit();
                   }}
                   messageList={["설정 텍스트 변경 성공"]}
                 />
               ));
             } catch {
-              overlay.open(({ isOpen, close }) => (
+              overlay.open((control) => (
                 <MessageDialog
-                  isDialogOpen={isOpen}
-                  onDialogClose={close}
+                  overlayControl={control}
                   messageList={["설정 텍스트 변경 실패"]}
                 />
               ));
@@ -121,7 +117,7 @@ const UserTextActionModal = ({
                 <Button type="submit" disabled={isSubmitting}>
                   수정
                 </Button>
-                <Button onClick={onClose}>닫기</Button>
+                <Button onClick={overlayControl.exit}>닫기</Button>
               </DialogActions>
             </StyledForm>
           )}

--- a/src/components/pages/QrScannerPage.tsx
+++ b/src/components/pages/QrScannerPage.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { CircularProgress } from "@mui/material";
+import { useOverlay } from "@toss/use-overlay";
 import { Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
@@ -29,6 +30,7 @@ const QrScannerPage = () => {
   const { scannedItemList } = useScannedItemList();
   const { goToNextPage, setPageAction } = usePageRouter();
   const { selectedInfoList } = useSelectedInfoList(); // 추후 커스텀 훅 개선 시 삭제 예정
+  const overlay = useOverlay();
 
   const handleDialogClose = () => {
     setIsDialogOpen(false);
@@ -63,13 +65,21 @@ const QrScannerPage = () => {
     }
   }, [scannedItemList, setMessageSnackBarState, t]);
 
-  return (
-    <StyledContainer>
+  useEffect(() => {
+    overlay.open((control) => (
       <MessageDialog
-        isDialogOpen={isDialogOpen}
-        onDialogClose={handleDialogClose}
+        overlayControl={control}
+        onDialogClose={() => {
+          handleDialogClose();
+        }}
         messageList={[t("Dialog1"), t("Dialog2")]}
       />
+    ));
+  }, []);
+
+  return (
+    <StyledContainer>
+      {/* NOTE: 다이얼로그를 직접 확인 눌러야 WeChat에서 카메라가 켜짐 */}
       {!isDialogOpen && (
         <ErrorBoundary
           fallbackRender={({ resetErrorBoundary }) => (

--- a/src/components/pages/UserSubmissionPage.tsx
+++ b/src/components/pages/UserSubmissionPage.tsx
@@ -84,10 +84,9 @@ const UserSubmissionPage = () => {
               goToPage("complete");
             }
           } catch (e) {
-            overlay.open(({ isOpen, close }) => (
+            overlay.open((control) => (
               <MessageDialog
-                isDialogOpen={isOpen}
-                onDialogClose={close}
+                overlayControl={control}
                 messageList={[t("Submission failed")]}
               />
             ));

--- a/src/components/pages/WeChatFriendGuidePage.tsx
+++ b/src/components/pages/WeChatFriendGuidePage.tsx
@@ -141,12 +141,8 @@ const UserIdCopyButton = () => {
         userIdCopyButtonRef.current.textContent = "复制好了";
       }
     } catch (e) {
-      overlay.open(({ isOpen, close }) => (
-        <MessageDialog
-          isDialogOpen={isOpen}
-          onDialogClose={close}
-          messageList={["复制失败"]}
-        />
+      overlay.open((control) => (
+        <MessageDialog overlayControl={control} messageList={["复制失败"]} />
       ));
     }
   };
@@ -189,13 +185,11 @@ const WeChatFriendGuidePage = () => {
 
   useEffect(() => {
     const action = () => {
-      overlay.open(({ isOpen, close }) => (
+      overlay.open((control) => (
         <Confirm
-          isConfirmOpen={isOpen}
-          onClose={close}
+          overlayControl={control}
           onConfirm={() => {
             goToNextPage();
-            close();
           }}
           content="你完成微信好友添加了吗？"
           confirmText="是"

--- a/src/const.ts
+++ b/src/const.ts
@@ -80,3 +80,9 @@ export interface Folder {
 }
 
 export type Language = "ko" | "zh" | "en" | "ja";
+
+export interface OverlayControl {
+  isOpen: boolean;
+  close: () => void;
+  exit: () => void;
+}


### PR DESCRIPTION
## 개요

### useOverlay의 메모리 누수에 대해서
기존에는 OverlayController가 제공하는 `close`, `exit` 중에서 `close`만 사용했습니다.
이는 `@toss/useOverlay`의 동작 원리를 잘 몰랐기 때문인데, `close`만 사용한다면 useOverlay 훅을 사용한 컴포넌트가 unmount 되어서야 OverlayProvider에 잔재하는 overlay가 사라지게 됩니다.
따라서 특정 모달을 닫을 때, exit으로 닫아야 모달을 닫을 때 OverlayProvider에서 overlay가 즉시 사라지게 되고 메모리 누수가 해결됩니다.

### `close`와 `exit`의 적절한 처리
그렇다고 전부 `exit`으로 처리하면 문제가 발생하게 됩니다.
예를 들어 아래 코드와 같이 모달은 닫으면서 안내의 형태로 `Dialog`를 보여주고 싶다면 기존 모달은 `close`만을 사용해서 메모리엔 남게 하고, `Dialog`를 닫을 시 모달도 같이 `exit`하도록 해야합니다. 그렇지 않으면 모달이 unmount 되면서 내부의 overlay도 함께 unmount 됩니다.
``` ts
const handleProductListCreate = async () => {
  try {
    await postProductList(
      transformProductExcelListToSubmitForm(newProductList, folder.id)
    );
    onProductListCreate();
    overlayControl.exit(); // API 요청 성공 시 모달을 닫으며 메모리에서 제거함
  } catch {
    overlayControl.close(); // 메세지 다이얼로그를 열면서 모달을 닫음. (메모리에선 존재함)
    overlay.open((control) => (
      <MessageDialog
        overlayControl={control}
        onDialogClose={() => {
          overlayControl.exit(); // 메세지 다이얼로그가 닫힐 때, 이 모달도 메모리에서 제거함
        }}
        messageList={["제품 생성 실패"]}
      />
    ));
  }
};
```

### onModalClose 이름에 대해서
기존 모달들은 공통적으로 overlay의 `isOpen`과 `close`를 넘겨받았습니다.
이를 넘겨받을 때, `onModalClose`라는 prop명으로 받았습니다.
`onModalClose`처럼 on이 붙는 경우는 이벤트 핸들러, 즉 모달이 닫힐 때 하게 될 행동들입니다.
하지만 `close` 자체는 모달을 닫는 행위이지 모달이 닫힐 때 동작할 행동이 아닙니다.
`handleModalClose` 또한 이벤트 핸들러명으로써 적절하지 않습니다.
이에 따라 `close`만을 넘겨준다면 앞으로는 `closeModal`이라고 명시하도록 하겠습니다.

별도로 `onModalClose`가 존재할 수도 있는데, 모달이 닫힐 때, 추가적인 행위가 필요하다면 그땐 해당 로직을 `onModalClose`에서 작성하면 됩니다.

### overlayControl
exit을 도입하게 되면서 매번 모달들은 공통적으로 3개의 prop을 넘겨받게됩니다.
`isModalOpen`, `closeModal`, `exitModal`.
이 세 개를 묶어서 `OverlayControl` 타입을 만들었고, 앞으로는 아래와 같이 모달에 바로 넘겨주도록 설계했습니다.
``` tsx
<MessageDialog
  overlayControl={control}
  onDialogClose={() => { // 메세지 다이얼로그가 닫힐 때, 추가적으로 할 행위를 선언
    overlayControl.exit();
  }}
  messageList={["제품 생성 실패"]}
/>
```

이제 `Dialog`, `Confirm`, `Modal`을 사용하는 개발자는 `close`, `exit`에 대해 신경쓰지 않아도 되고, 닫힐 때 추가적인 행위를 선언하고싶다면 `on{컴포넌트}Close`를 통해서 처리하면 됩니다.

변수명이 `overlayControl`, `control`인 이유는 기존 `isOpen`, `close`, `exit`이 OverlayController에서 오기 때문입니다. overlay를 제어하는 프로퍼티들이기도 하고요.


## 변경 사항

- 기존 모달을 닫을 때, overlay controller의 `close`만 사용하던 것을 `exit`도 적절히 사용하여 메모리 누수 해결
- 기존 모달 컴포넌트에 `isModalOpen`, `onModalClose`를 넘겨주던 것을 `overlayControl`을 넘겨주는 것으로 통일
- onDialogClose 등에 대해서 async에 대한 처리를 할 수 있게 `Promise<void>`도 받을 수 있도록 처리
- Dialog, Confirm, 기타 모달들을 overlay로만 쓰도록 변경 (OverlayControl 타입 도입)
    이를 위해 `QrScannerPage`에서의 `MessageDialog`를 useEffect를 통해서 구현으로 변경

## To Reviewers

### TODO
- 각 독립적인 overlay로 나누기
- ProductDetailModal, ProductEditModal 순환 의존 구조 해결

