### PR TITLE
useOverlay 별도의 overlay로 분리하기 #298

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@mui/material": "^5.15.15",
         "@mui/x-data-grid": "^7.5.1",
         "@react-pdf/renderer": "^3.4.4",
-        "@toss/use-overlay": "^1.4.0",
         "dayjs": "^1.11.11",
         "formik": "^2.4.5",
         "franc": "^6.2.0",
@@ -3150,14 +3149,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@toss/use-overlay": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@toss/use-overlay/-/use-overlay-1.4.0.tgz",
-      "integrity": "sha512-1fkKRwUWaPn1fPTHeYiOdnQu4j6sHLDfJZS1smsarPxWxUlr1+FikNIjzYQGAVXgNjxw0cqNfKR4HvVSsM5w3A==",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@mui/material": "^5.15.15",
     "@mui/x-data-grid": "^7.5.1",
     "@react-pdf/renderer": "^3.4.4",
-    "@toss/use-overlay": "^1.4.0",
     "dayjs": "^1.11.11",
     "formik": "^2.4.5",
     "franc": "^6.2.0",

--- a/src/app/[locale]/manager/page.tsx
+++ b/src/app/[locale]/manager/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { OverlayProvider } from "@toss/use-overlay";
-
 import initTranslations from "@/app/i18n";
 import TranslationsProvider from "@/components/common/TranslationsProvider";
 import ManagerPage from "@/components/pages/ManagerPage";
 import GlobalStyle from "@/globalStyles";
+import { OverlayProvider } from "@/hooks/useOverlay";
 
 const i18nNamespaces = ["common"];
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { OverlayProvider } from "@toss/use-overlay";
 import { RecoilRoot } from "recoil";
 
 import initTranslations from "@/app/i18n";
@@ -9,6 +8,7 @@ import TranslationsProvider from "@/components/common/TranslationsProvider";
 import MainPage from "@/components/pages/MainPage";
 import "@/dayjsConfig";
 import GlobalStyle from "@/globalStyles";
+import { OverlayProvider } from "@/hooks/useOverlay";
 
 const i18nNamespaces = ["common"];
 

--- a/src/components/manager/Dashboard.tsx
+++ b/src/components/manager/Dashboard.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { useOverlay } from "@toss/use-overlay";
 import { useEffect, useState } from "react";
 
 import { getFolderList } from "@/api/folders";
@@ -12,6 +11,7 @@ import ProductBoard from "@/components/manager/product/ProductBoard";
 import UserBoard from "@/components/manager/user/UserBoard";
 import { sortFolderListByType } from "@/components/manager/util";
 import { Folder } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const StyledBoardContainer = styled.div`
   display: flex;

--- a/src/components/manager/Menu.tsx
+++ b/src/components/manager/Menu.tsx
@@ -19,7 +19,7 @@ import FolderActionModal from "@/components/manager/folder/FolderActionModal";
 import FolderCreationModal from "@/components/manager/folder/FolderCreationModal";
 import { sortFolderListByType } from "@/components/manager/util";
 import { Folder } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 
 interface StyledListItemTextProp {
   selected: boolean;
@@ -56,7 +56,7 @@ const NestedListItem = ({
   onMenuChange: (folder: Folder) => void;
   onFolderDelete: () => void;
 }) => {
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(2);
   const [isNestedListOpen, setIsNestedListOpen] = useState<boolean>(true);
 
   const handleNestedList = () => {
@@ -105,7 +105,7 @@ const NestedListItem = ({
                 <EditIcon
                   onClick={(e) => {
                     e.stopPropagation();
-                    overlay.open((control) => (
+                    overlays[0].open((control) => (
                       <FolderActionModal
                         overlayControl={control}
                         folder={folder}
@@ -122,7 +122,7 @@ const NestedListItem = ({
         <ListItem>
           <ListItemButton
             onClick={() => {
-              overlay.open((control) => (
+              overlays[1].open((control) => (
                 <FolderCreationModal
                   overlayControl={control}
                   type={folderList[0].type}

--- a/src/components/manager/Menu.tsx
+++ b/src/components/manager/Menu.tsx
@@ -11,7 +11,6 @@ import {
   ListItemText,
   Toolbar,
 } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { useState } from "react";
 
 import Icons from "@/components/common/Icons";
@@ -20,6 +19,7 @@ import FolderActionModal from "@/components/manager/folder/FolderActionModal";
 import FolderCreationModal from "@/components/manager/folder/FolderCreationModal";
 import { sortFolderListByType } from "@/components/manager/util";
 import { Folder } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 interface StyledListItemTextProp {
   selected: boolean;

--- a/src/components/manager/folder/DataFolderReassignModal.tsx
+++ b/src/components/manager/folder/DataFolderReassignModal.tsx
@@ -6,12 +6,12 @@ import {
   FormControlLabel,
   Modal,
 } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { Field, Form, Formik } from "formik";
 import * as Yup from "yup";
 
 import MessageDialog from "@/components/common/MessageDialog";
 import { Folder, OverlayControl, Product, User } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 import { reassignFolder } from "@/services/folders";
 
 const StyledModalContainer = styled.div`

--- a/src/components/manager/folder/FolderActionModal.tsx
+++ b/src/components/manager/folder/FolderActionModal.tsx
@@ -45,6 +45,7 @@ const FolderActionModal = ({
         await deleteFolder(undefined, id);
         onFolderListUpdate();
         onFolderDelete();
+        overlayControl.exit();
       } catch {
         overlay.open((control) => (
           <MessageDialog
@@ -102,14 +103,11 @@ const FolderActionModal = ({
                 <Button
                   disabled={isSubmitting || deletionFormik.isSubmitting}
                   onClick={() => {
-                    overlayControl.close();
                     overlay.open((control) => (
                       <Confirm
                         overlayControl={control}
-                        onClose={overlayControl.exit}
                         onConfirm={async () => {
                           await deletionFormik.submitForm();
-                          overlayControl.exit();
                         }}
                         content={
                           "폴더 삭제 시 내부 데이터는 휴지통으로 이동합니다. 삭제하시겠습니까?"

--- a/src/components/manager/folder/FolderActionModal.tsx
+++ b/src/components/manager/folder/FolderActionModal.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { Button, DialogActions, Modal, TextField } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { Field, Form, Formik, useFormik } from "formik";
 import * as Yup from "yup";
 
@@ -8,6 +7,7 @@ import { deleteFolder, patchFolder } from "@/api/folders";
 import Confirm from "@/components/common/Confirm";
 import MessageDialog from "@/components/common/MessageDialog";
 import { Folder, OverlayControl } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;

--- a/src/components/manager/folder/FolderActionModal.tsx
+++ b/src/components/manager/folder/FolderActionModal.tsx
@@ -7,7 +7,7 @@ import { deleteFolder, patchFolder } from "@/api/folders";
 import Confirm from "@/components/common/Confirm";
 import MessageDialog from "@/components/common/MessageDialog";
 import { Folder, OverlayControl } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -34,7 +34,7 @@ const FolderActionModal = ({
   onFolderListUpdate: () => void;
   onFolderDelete: () => void;
 }) => {
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(3);
   const { name, type, id } = folder;
 
   const deletionFormik = useFormik({
@@ -47,7 +47,7 @@ const FolderActionModal = ({
         onFolderDelete();
         overlayControl.exit();
       } catch {
-        overlay.open((control) => (
+        overlays[0].open((control) => (
           <MessageDialog
             overlayControl={control}
             messageList={["폴더 삭제 실패"]}
@@ -72,7 +72,7 @@ const FolderActionModal = ({
               onFolderListUpdate();
               overlayControl.exit();
             } catch {
-              overlay.open((control) => (
+              overlays[1].open((control) => (
                 <MessageDialog
                   overlayControl={control}
                   messageList={["폴더 수정 실패"]}
@@ -103,7 +103,7 @@ const FolderActionModal = ({
                 <Button
                   disabled={isSubmitting || deletionFormik.isSubmitting}
                   onClick={() => {
-                    overlay.open((control) => (
+                    overlays[2].open((control) => (
                       <Confirm
                         overlayControl={control}
                         onConfirm={async () => {

--- a/src/components/manager/folder/FolderActionModal.tsx
+++ b/src/components/manager/folder/FolderActionModal.tsx
@@ -106,8 +106,10 @@ const FolderActionModal = ({
                     overlay.open((control) => (
                       <Confirm
                         overlayControl={control}
+                        onClose={overlayControl.exit}
                         onConfirm={async () => {
                           await deletionFormik.submitForm();
+                          overlayControl.exit();
                         }}
                         content={
                           "폴더 삭제 시 내부 데이터는 휴지통으로 이동합니다. 삭제하시겠습니까?"

--- a/src/components/manager/folder/FolderCreationModal.tsx
+++ b/src/components/manager/folder/FolderCreationModal.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { Button, DialogActions, Modal, TextField } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { Field, Form, Formik } from "formik";
 import * as Yup from "yup";
 
 import { postFolder } from "@/api/folders";
 import MessageDialog from "@/components/common/MessageDialog";
 import { OverlayControl } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;

--- a/src/components/manager/product/ExcelProductCreateModal.tsx
+++ b/src/components/manager/product/ExcelProductCreateModal.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { Button, DialogActions, Modal } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { useState } from "react";
 import { FileUploader } from "react-drag-drop-files";
 import * as XLSX from "xlsx";
@@ -14,6 +13,7 @@ import {
 import ExcelProductTableModal from "@/components/manager/product/ExcelProductTableModal";
 import { handleExcelFileProductList } from "@/components/manager/product/util";
 import { Folder, OverlayControl, Product } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;

--- a/src/components/manager/product/ExcelProductCreateModal.tsx
+++ b/src/components/manager/product/ExcelProductCreateModal.tsx
@@ -13,7 +13,7 @@ import {
 import ExcelProductTableModal from "@/components/manager/product/ExcelProductTableModal";
 import { handleExcelFileProductList } from "@/components/manager/product/util";
 import { Folder, OverlayControl, Product } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -65,7 +65,7 @@ const ExcelProductCreateModal = ({
   });
   const { newProductList, existingProductList, errorProductList } =
     handledProductList;
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(4);
 
   const handleExcelFileUpload = (file: File) => {
     setIsFileUploaded(true);
@@ -91,7 +91,7 @@ const ExcelProductCreateModal = ({
       onProductListCreate();
       overlayControl.exit();
     } catch {
-      overlay.open((control) => (
+      overlays[0].open((control) => (
         <MessageDialog
           overlayControl={control}
           onDialogClose={() => {
@@ -128,7 +128,7 @@ const ExcelProductCreateModal = ({
               <Button
                 variant="text"
                 onClick={() => {
-                  overlay.open((control) => (
+                  overlays[1].open((control) => (
                     <ExcelProductTableModal
                       overlayControl={control}
                       productList={newProductList}
@@ -144,7 +144,7 @@ const ExcelProductCreateModal = ({
               <Button
                 variant="text"
                 onClick={() => {
-                  overlay.open((control) => (
+                  overlays[2].open((control) => (
                     <ExcelProductTableModal
                       overlayControl={control}
                       productList={existingProductList}
@@ -160,7 +160,7 @@ const ExcelProductCreateModal = ({
               <Button
                 variant="text"
                 onClick={() => {
-                  overlay.open((control) => (
+                  overlays[3].open((control) => (
                     <ExcelProductTableModal
                       overlayControl={control}
                       productList={errorProductList}

--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import JSZip from "jszip";
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
@@ -13,6 +12,7 @@ import ExcelProductCreateModal from "@/components/manager/product/ExcelProductCr
 import ProductCreateModal from "@/components/manager/product/ProductCreateModal";
 import ProductTable from "@/components/manager/product/ProductTable";
 import { Folder, Product } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 import { reassignFolder } from "@/services/folders";
 import { deleteProductList } from "@/services/products";
 

--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -12,7 +12,7 @@ import ExcelProductCreateModal from "@/components/manager/product/ExcelProductCr
 import ProductCreateModal from "@/components/manager/product/ProductCreateModal";
 import ProductTable from "@/components/manager/product/ProductTable";
 import { Folder, Product } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 import { reassignFolder } from "@/services/folders";
 import { deleteProductList } from "@/services/products";
 
@@ -49,14 +49,14 @@ const ProductBoard = ({
     return p.metadata.folderId === folder.id;
   });
   const [selectedProductList, setSelectedProductList] = useState<string[]>([]);
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(8);
 
   const handleProductListUpdate = async () => {
     try {
       const productList = await getProductList();
       setProductList(productList);
     } catch {
-      overlay.open((control) => (
+      overlays[0].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 가져오기 실패"]}
@@ -75,7 +75,7 @@ const ProductBoard = ({
       );
       await handleProductListUpdate();
     } catch {
-      overlay.open((control) => (
+      overlays[1].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 복구 실패"]}
@@ -94,7 +94,7 @@ const ProductBoard = ({
       );
       await handleProductListUpdate();
     } catch {
-      overlay.open((control) => (
+      overlays[2].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 삭제 실패"]}
@@ -108,7 +108,7 @@ const ProductBoard = ({
       await deleteProductList(selectedProductList);
       await handleProductListUpdate();
     } catch {
-      overlay.open((control) => (
+      overlays[3].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 영구 삭제 실패"]}
@@ -157,7 +157,7 @@ const ProductBoard = ({
         }
         downloadLink.click();
       } catch (e) {
-        overlay.open((control) => (
+        overlays[4].open((control) => (
           <MessageDialog
             overlayControl={control}
             messageList={[e?.message ?? "QR code 생성 실패"]}
@@ -169,7 +169,7 @@ const ProductBoard = ({
 
   const handleProductFolderReassign = () => {
     if (selectedProductList.length > 0) {
-      overlay.open((control) => (
+      overlays[5].open((control) => (
         <DataFolderReassignModal
           overlayControl={control}
           selectedDataList={filteredProductList.filter((f) =>
@@ -209,7 +209,7 @@ const ProductBoard = ({
               </Button>
               <Button
                 onClick={() => {
-                  overlay.open((control) => (
+                  overlays[6].open((control) => (
                     <ProductCreateModal
                       overlayControl={control}
                       folder={folder}
@@ -222,7 +222,7 @@ const ProductBoard = ({
               </Button>
               <Button
                 onClick={() => {
-                  overlay.open((control) => (
+                  overlays[7].open((control) => (
                     <ExcelProductCreateModal
                       overlayControl={control}
                       folder={folder}

--- a/src/components/manager/product/ProductCreateModal.tsx
+++ b/src/components/manager/product/ProductCreateModal.tsx
@@ -1,5 +1,4 @@
 import { Button, TextField } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { useFormik } from "formik";
 import { useEffect, useRef } from "react";
 import { FileUploader } from "react-drag-drop-files";
@@ -18,6 +17,7 @@ import {
   productCreationSchema,
 } from "@/components/manager/product/const";
 import { Folder, OverlayControl } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const ProductCreateModal = ({
   overlayControl,

--- a/src/components/manager/product/ProductDetailModal.int.test.tsx
+++ b/src/components/manager/product/ProductDetailModal.int.test.tsx
@@ -1,10 +1,10 @@
 import "@testing-library/jest-dom";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { OverlayProvider } from "@toss/use-overlay";
 
 import { mockProductList } from "@/components/manager/product/const";
 import ProductDetailModal from "@/components/manager/product/ProductDetailModal";
+import { OverlayProvider } from "@/hooks/useOverlay";
 
 describe("ProductDetailModal", () => {
   it("초기 렌더링 확인", async () => {

--- a/src/components/manager/product/ProductDetailModal.tsx
+++ b/src/components/manager/product/ProductDetailModal.tsx
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
-import { useOverlay } from "@toss/use-overlay";
 
 import ImageWithFallback from "@/components/common/ImageWithFallback";
 import { StyledModal } from "@/components/manager/DashboardItems";
 import { productDetailColumns } from "@/components/manager/product/const";
 import ProductEditModal from "@/components/manager/product/ProductEditModal";
 import { OverlayControl, Product } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const StyledDetailModalContainer = styled.div`
   position: relative;

--- a/src/components/manager/product/ProductEditModal.tsx
+++ b/src/components/manager/product/ProductEditModal.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/manager/product/const";
 import ProductDetailModal from "@/components/manager/product/ProductDetailModal";
 import { OverlayControl, Product } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 
 const ProductEditModal = ({
   overlayControl,
@@ -27,7 +27,7 @@ const ProductEditModal = ({
   overlayControl: OverlayControl;
   product: Product;
 }) => {
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(3);
   const formik = useFormik({
     initialValues: productEditionInitialValues,
     validateOnMount: true,
@@ -59,12 +59,12 @@ const ProductEditModal = ({
 
       try {
         const res = await putProduct(formData, product.productId);
-        overlay.open((control) => (
+        overlays[0].open((control) => (
           <ProductDetailModal overlayControl={control} modalProductData={res} />
         ));
         overlayControl.close();
       } catch (e) {
-        overlay.open((control) => (
+        overlays[1].open((control) => (
           <MessageDialog overlayControl={control} messageList={[e.message]} />
         ));
       }
@@ -189,7 +189,7 @@ const ProductEditModal = ({
           </Button>
           <Button
             onClick={() => {
-              overlay.open((control) => (
+              overlays[2].open((control) => (
                 <ProductDetailModal
                   overlayControl={control}
                   modalProductData={product}

--- a/src/components/manager/product/ProductEditModal.tsx
+++ b/src/components/manager/product/ProductEditModal.tsx
@@ -1,5 +1,4 @@
 import { Button, TextField } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { useFormik } from "formik";
 import { useEffect, useRef } from "react";
 import { FileUploader } from "react-drag-drop-files";
@@ -19,6 +18,7 @@ import {
 } from "@/components/manager/product/const";
 import ProductDetailModal from "@/components/manager/product/ProductDetailModal";
 import { OverlayControl, Product } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const ProductEditModal = ({
   overlayControl,

--- a/src/components/manager/product/ProductTable.test.tsx
+++ b/src/components/manager/product/ProductTable.test.tsx
@@ -1,12 +1,12 @@
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { OverlayProvider } from "@toss/use-overlay";
 
 import {
   mockProductFolderList,
   mockProductList,
 } from "@/components/manager/product/const";
 import ProductTable from "@/components/manager/product/ProductTable";
+import { OverlayProvider } from "@/hooks/useOverlay";
 
 const mockSetSelectedProductList = jest.fn();
 

--- a/src/components/manager/product/ProductTable.tsx
+++ b/src/components/manager/product/ProductTable.tsx
@@ -1,5 +1,4 @@
 import { DataGrid, GridCellParams, GridColDef } from "@mui/x-data-grid";
-import { useOverlay } from "@toss/use-overlay";
 import { Dispatch, SetStateAction } from "react";
 
 import { PRODUCT_DEFAULT } from "@/components/manager/const";
@@ -7,6 +6,7 @@ import { ProductTableRow } from "@/components/manager/product/const";
 import ProductDetailModal from "@/components/manager/product/ProductDetailModal";
 import { handleProductListForTable } from "@/components/manager/product/util";
 import { Folder, Product } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const columns: GridColDef[] = [
   { field: "id", headerName: "제품 ID", width: 150 },

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { pdf } from "@react-pdf/renderer";
-import { useOverlay } from "@toss/use-overlay";
 import JSZip from "jszip";
 import { useEffect, useState } from "react";
 
@@ -21,6 +20,7 @@ import {
   CountryType,
 } from "@/components/user/userSubmission/countries";
 import { Folder, Product, User } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 import { imageUrlList } from "@/recoil/user/atoms/imageUrlListState";
 import { SelectedInfoList } from "@/recoil/user/atoms/selectedInfoListState";
 import { reassignFolder } from "@/services/folders";

--- a/src/components/manager/user/UserBoard.tsx
+++ b/src/components/manager/user/UserBoard.tsx
@@ -20,7 +20,7 @@ import {
   CountryType,
 } from "@/components/user/userSubmission/countries";
 import { Folder, Product, User } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 import { imageUrlList } from "@/recoil/user/atoms/imageUrlListState";
 import { SelectedInfoList } from "@/recoil/user/atoms/selectedInfoListState";
 import { reassignFolder } from "@/services/folders";
@@ -57,7 +57,7 @@ const UserBoard = ({
     return u.metadata.folderId === folder.id;
   });
   const [selectedUserList, setSelectedUserList] = useState<string[]>([]);
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(8);
   const [productList, setProductList] = useState<Product[]>([]);
 
   const updateUserList = async () => {
@@ -65,7 +65,7 @@ const UserBoard = ({
       const userList = await getUserList();
       setUserList(userList);
     } catch {
-      overlay.open((control) => (
+      overlays[0].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 가져오기 실패"]}
@@ -84,7 +84,7 @@ const UserBoard = ({
       );
       await updateUserList();
     } catch {
-      overlay.open((control) => (
+      overlays[1].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 복구 실패"]}
@@ -103,7 +103,7 @@ const UserBoard = ({
       );
       await updateUserList();
     } catch {
-      overlay.open((control) => (
+      overlays[2].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 삭제 실패"]}
@@ -117,7 +117,7 @@ const UserBoard = ({
       await deleteUserList(selectedUserList);
       await updateUserList();
     } catch {
-      overlay.open((control) => (
+      overlays[3].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["데이터 영구 삭제 실패"]}
@@ -128,7 +128,7 @@ const UserBoard = ({
 
   const handleUserFolderReassign = () => {
     if (selectedUserList.length > 0) {
-      overlay.open((control) => (
+      overlays[4].open((control) => (
         <DataFolderReassignModal
           overlayControl={control}
           selectedDataList={filteredUserList.filter((f) =>
@@ -233,7 +233,7 @@ const UserBoard = ({
       const productList = await getProductList();
       setProductList(productList);
     } catch {
-      overlay.open((control) => (
+      overlays[5].open((control) => (
         <MessageDialog
           overlayControl={control}
           messageList={["제품 목록 받아오기 실패"]}
@@ -255,7 +255,7 @@ const UserBoard = ({
           {folder.id === USER_DEFAULT && (
             <Button
               onClick={() => {
-                overlay.open((control) => (
+                overlays[6].open((control) => (
                   <UserTextActionModal overlayControl={control} />
                 ));
               }}
@@ -277,7 +277,7 @@ const UserBoard = ({
               </Button>
               <Button
                 onClick={() => {
-                  overlay.open((control) => (
+                  overlays[7].open((control) => (
                     <UserCopyModal
                       overlayControl={control}
                       selectedUserList={filteredUserList.filter((f) =>

--- a/src/components/manager/user/UserTable.tsx
+++ b/src/components/manager/user/UserTable.tsx
@@ -12,7 +12,7 @@ import {
 import UserDetailModal from "@/components/manager/user/UserDetailModal";
 import { handleUserListForTable } from "@/components/manager/user/util";
 import { Folder, User } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 import { transformUserForUpdate } from "@/services/util";
 
 const UserTable = ({
@@ -27,7 +27,7 @@ const UserTable = ({
   setSelectedUserList: Dispatch<SetStateAction<string[]>>;
 }) => {
   const tableRows = handleUserListForTable(userList, folderList);
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(2);
 
   const handleRemarkUpdate = async (
     row: UserTableRow,
@@ -41,7 +41,7 @@ const UserTable = ({
     } catch (e) {
       old.__user__.remark1 = old.remark1;
       old.__user__.remark2 = old.remark2;
-      overlay.open((control) => (
+      overlays[0].open((control) => (
         <MessageDialog overlayControl={control} messageList={[e.message]} />
       ));
       return old;
@@ -72,7 +72,7 @@ const UserTable = ({
             cell.field !== "remark2"
           ) {
             e.stopPropagation();
-            overlay.open((control) => (
+            overlays[1].open((control) => (
               <UserDetailModal
                 overlayControl={control}
                 modalUserData={cell.row.__user__}

--- a/src/components/manager/user/UserTable.tsx
+++ b/src/components/manager/user/UserTable.tsx
@@ -1,5 +1,4 @@
 import { DataGrid, GridCellParams } from "@mui/x-data-grid";
-import { useOverlay } from "@toss/use-overlay";
 import { Dispatch, SetStateAction } from "react";
 
 import { putUser } from "@/api/users";
@@ -13,6 +12,7 @@ import {
 import UserDetailModal from "@/components/manager/user/UserDetailModal";
 import { handleUserListForTable } from "@/components/manager/user/util";
 import { Folder, User } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 import { transformUserForUpdate } from "@/services/util";
 
 const UserTable = ({

--- a/src/components/manager/user/UserTextActionModal.tsx
+++ b/src/components/manager/user/UserTextActionModal.tsx
@@ -1,5 +1,4 @@
 import { Button, DialogActions, Modal, TextField } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { Field, Form, Formik } from "formik";
 import { useEffect, useState } from "react";
 import { styled } from "styled-components";
@@ -8,6 +7,7 @@ import * as Yup from "yup";
 import { getText, putText } from "@/api/text";
 import MessageDialog from "@/components/common/MessageDialog";
 import { OverlayControl } from "@/const";
+import { useOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;

--- a/src/components/manager/user/UserTextActionModal.tsx
+++ b/src/components/manager/user/UserTextActionModal.tsx
@@ -7,7 +7,7 @@ import * as Yup from "yup";
 import { getText, putText } from "@/api/text";
 import MessageDialog from "@/components/common/MessageDialog";
 import { OverlayControl } from "@/const";
-import { useOverlay } from "@/hooks/useOverlay";
+import { useMultipleOverlay } from "@/hooks/useOverlay";
 
 const StyledModalContainer = styled.div`
   position: absolute;
@@ -39,14 +39,14 @@ const UserTextActionModal = ({
   overlayControl: OverlayControl;
 }) => {
   const [initialText, setInitialText] = useState("");
-  const overlay = useOverlay();
+  const overlays = useMultipleOverlay(3);
 
   const handleTextUpdate = async () => {
     try {
       const { text } = await getText();
       setInitialText(text);
     } catch {
-      overlay.open((control) => (
+      overlays[0].open((control) => (
         <MessageDialog
           overlayControl={control}
           onDialogClose={() => {
@@ -82,7 +82,7 @@ const UserTextActionModal = ({
           onSubmit={async (values, { setSubmitting }) => {
             try {
               await putText(JSON.stringify(values));
-              overlay.open((control) => (
+              overlays[1].open((control) => (
                 <MessageDialog
                   overlayControl={control}
                   onDialogClose={() => {
@@ -92,7 +92,7 @@ const UserTextActionModal = ({
                 />
               ));
             } catch {
-              overlay.open((control) => (
+              overlays[2].open((control) => (
                 <MessageDialog
                   overlayControl={control}
                   messageList={["설정 텍스트 변경 실패"]}

--- a/src/components/pages/QrScannerPage.tsx
+++ b/src/components/pages/QrScannerPage.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { CircularProgress } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import { Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
@@ -10,6 +9,7 @@ import MessageDialog from "@/components/common/MessageDialog";
 import { snackBarStatusMessage } from "@/components/const";
 import QrCode from "@/components/user/qrScanner/QrCode";
 import RetryButton from "@/components/user/RetryButton";
+import { useOverlay } from "@/hooks/useOverlay";
 import usePageRouter from "@/hooks/user/usePageRouter";
 import useScannedItemList from "@/hooks/user/useScannedItemList";
 import useSelectedInfoList from "@/hooks/user/useSelectedInfoList";

--- a/src/components/pages/UserSubmissionPage.tsx
+++ b/src/components/pages/UserSubmissionPage.tsx
@@ -1,4 +1,3 @@
-import { useOverlay } from "@toss/use-overlay";
 import { Formik, FormikState } from "formik";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,6 +15,7 @@ import { formatSubmitUserBody } from "@/components/user/userSubmission/utils";
 import { userInfoValidationSchema } from "@/components/user/userSubmission/validation";
 import { Language } from "@/const";
 import dayjs from "@/dayjsConfig";
+import { useOverlay } from "@/hooks/useOverlay";
 import useLocalStorageState from "@/hooks/user/useLocalStorageState";
 import usePageRouter from "@/hooks/user/usePageRouter";
 import useScannedItemList from "@/hooks/user/useScannedItemList";

--- a/src/components/pages/WeChatFriendGuidePage.tsx
+++ b/src/components/pages/WeChatFriendGuidePage.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
-import { useOverlay } from "@toss/use-overlay";
 import Image from "next/image";
 import { ReactNode, useEffect, useRef } from "react";
 import { useRecoilValue } from "recoil";
 
 import Confirm from "@/components/common/Confirm";
 import MessageDialog from "@/components/common/MessageDialog";
+import { useOverlay } from "@/hooks/useOverlay";
 import usePageRouter from "@/hooks/user/usePageRouter";
 import { userIdState } from "@/recoil/user/atoms/userIdState";
 

--- a/src/hooks/useOverlay/OverlayController.tsx
+++ b/src/hooks/useOverlay/OverlayController.tsx
@@ -1,0 +1,52 @@
+// 참고: https://github.com/toss/slash/tree/main/packages/react/use-overlay
+import {
+  forwardRef,
+  Ref,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+
+import { CreateOverlayElement } from "@/hooks/useOverlay/types";
+
+interface Props {
+  overlayElement: CreateOverlayElement;
+  onExit: () => void;
+}
+
+export interface OverlayControlRef {
+  close: () => void;
+}
+
+export const OverlayController = forwardRef(function OverlayController(
+  { overlayElement: OverlayElement, onExit }: Props,
+  ref: Ref<OverlayControlRef>
+) {
+  const [isOpenOverlay, setIsOpenOverlay] = useState(false);
+
+  const handleOverlayClose = useCallback(() => setIsOpenOverlay(false), []);
+
+  useImperativeHandle(
+    ref,
+    () => {
+      return { close: handleOverlayClose };
+    },
+    [handleOverlayClose]
+  );
+
+  useEffect(() => {
+    // NOTE: requestAnimationFrame이 없으면 가끔 Open 애니메이션이 실행되지 않는다.
+    requestAnimationFrame(() => {
+      setIsOpenOverlay(true);
+    });
+  }, []);
+
+  return (
+    <OverlayElement
+      isOpen={isOpenOverlay}
+      close={handleOverlayClose}
+      exit={onExit}
+    />
+  );
+});

--- a/src/hooks/useOverlay/OverlayProvider.tsx
+++ b/src/hooks/useOverlay/OverlayProvider.tsx
@@ -13,7 +13,7 @@ export const OverlayContext = createContext<{
   unmount(id: string): void;
 } | null>(null);
 
-export function OverlayProvider({ children }: PropsWithChildren) {
+export const OverlayProvider = ({ children }: PropsWithChildren) => {
   const [overlayById, setOverlayById] = useState<Map<string, ReactNode>>(
     new Map()
   );
@@ -44,4 +44,4 @@ export function OverlayProvider({ children }: PropsWithChildren) {
       ))}
     </OverlayContext.Provider>
   );
-}
+};

--- a/src/hooks/useOverlay/OverlayProvider.tsx
+++ b/src/hooks/useOverlay/OverlayProvider.tsx
@@ -1,0 +1,47 @@
+// 참고: https://github.com/toss/slash/tree/main/packages/react/use-overlay
+import React, {
+  createContext,
+  PropsWithChildren,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+
+export const OverlayContext = createContext<{
+  mount(id: string, element: ReactNode): void;
+  unmount(id: string): void;
+} | null>(null);
+
+export function OverlayProvider({ children }: PropsWithChildren) {
+  const [overlayById, setOverlayById] = useState<Map<string, ReactNode>>(
+    new Map()
+  );
+
+  const mount = useCallback((id: string, element: ReactNode) => {
+    setOverlayById((overlayById) => {
+      const cloned = new Map(overlayById);
+      cloned.set(id, element);
+      return cloned;
+    });
+  }, []);
+
+  const unmount = useCallback((id: string) => {
+    setOverlayById((overlayById) => {
+      const cloned = new Map(overlayById);
+      cloned.delete(id);
+      return cloned;
+    });
+  }, []);
+
+  const context = useMemo(() => ({ mount, unmount }), [mount, unmount]);
+
+  return (
+    <OverlayContext.Provider value={context}>
+      {children}
+      {Array.from(overlayById.entries()).map(([id, element]) => (
+        <React.Fragment key={id}>{element}</React.Fragment>
+      ))}
+    </OverlayContext.Provider>
+  );
+}

--- a/src/hooks/useOverlay/index.ts
+++ b/src/hooks/useOverlay/index.ts
@@ -1,0 +1,3 @@
+export { OverlayProvider } from "@/hooks/useOverlay/OverlayProvider";
+export { useMultipleOverlay } from "@/hooks/useOverlay/useMultipleOverlay";
+export { useOverlay } from "@/hooks/useOverlay/useOverlay";

--- a/src/hooks/useOverlay/types.ts
+++ b/src/hooks/useOverlay/types.ts
@@ -1,0 +1,6 @@
+// 참고: https://github.com/toss/slash/tree/main/packages/react/use-overlay
+export type CreateOverlayElement = (props: {
+  isOpen: boolean;
+  close: () => void;
+  exit: () => void;
+}) => JSX.Element;

--- a/src/hooks/useOverlay/useMultipleOverlay.tsx
+++ b/src/hooks/useOverlay/useMultipleOverlay.tsx
@@ -1,0 +1,79 @@
+// 참고: https://github.com/toss/slash/tree/main/packages/react/use-overlay
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  OverlayController,
+  OverlayControlRef,
+} from "@/hooks/useOverlay/OverlayController";
+import { OverlayContext } from "@/hooks/useOverlay/OverlayProvider";
+import { CreateOverlayElement } from "@/hooks/useOverlay/types";
+
+let elementId = 1;
+
+export function useMultipleOverlay(
+  count: number,
+  nonExitOnUnmountList: number[]
+) {
+  const context = useContext(OverlayContext);
+
+  if (context == null) {
+    throw new Error(
+      "useMultipleOverlay is only available within OverlayProvider."
+    );
+  }
+
+  if (count < 1) {
+    throw new Error("useMultipleOverlay는 overlay가 1개 이상이어야 합니다.");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { mount, unmount } = context;
+  const [ids] = useState(() => {
+    const res = Array.from(
+      { length: count },
+      (_, i) => `mult-${elementId + i}`
+    );
+    elementId += count;
+    return res;
+  });
+
+  const overlayRefs = useRef<(OverlayControlRef | null)[]>(
+    Array(count).fill(null)
+  );
+
+  useEffect(() => {
+    return () => {
+      ids.forEach((id, index) => {
+        if (!nonExitOnUnmountList.includes(index)) {
+          unmount(id);
+        }
+      });
+    };
+  }, [ids, nonExitOnUnmountList, unmount]);
+
+  return useMemo(() => {
+    const overlays = ids.map((id, index) => ({
+      open: (overlayElement: CreateOverlayElement) => {
+        mount(
+          id,
+          <OverlayController
+            key={Date.now()}
+            ref={overlayRefs[index]}
+            overlayElement={overlayElement}
+            onExit={() => {
+              unmount(id);
+            }}
+          />
+        );
+      },
+      close: () => {
+        overlayRefs.current[index]?.close();
+      },
+      exit: () => {
+        unmount(id);
+      },
+    }));
+
+    return overlays;
+  }, [ids, mount, unmount]);
+}

--- a/src/hooks/useOverlay/useMultipleOverlay.tsx
+++ b/src/hooks/useOverlay/useMultipleOverlay.tsx
@@ -12,7 +12,7 @@ let elementId = 1;
 
 export function useMultipleOverlay(
   count: number,
-  nonExitOnUnmountList: number[]
+  nonExitOnUnmountList?: number[]
 ) {
   const context = useContext(OverlayContext);
 
@@ -44,7 +44,7 @@ export function useMultipleOverlay(
   useEffect(() => {
     return () => {
       ids.forEach((id, index) => {
-        if (!nonExitOnUnmountList.includes(index)) {
+        if (!nonExitOnUnmountList || !nonExitOnUnmountList.includes(index)) {
           unmount(id);
         }
       });

--- a/src/hooks/useOverlay/useMultipleOverlay.tsx
+++ b/src/hooks/useOverlay/useMultipleOverlay.tsx
@@ -10,10 +10,10 @@ import { CreateOverlayElement } from "@/hooks/useOverlay/types";
 
 let elementId = 1;
 
-export function useMultipleOverlay(
+export const useMultipleOverlay = (
   count: number,
   nonExitOnUnmountList?: number[]
-) {
+) => {
   const context = useContext(OverlayContext);
 
   if (context == null) {
@@ -78,4 +78,4 @@ export function useMultipleOverlay(
 
     return overlays;
   }, [ids, mount, unmount]);
-}
+};

--- a/src/hooks/useOverlay/useMultipleOverlay.tsx
+++ b/src/hooks/useOverlay/useMultipleOverlay.tsx
@@ -58,7 +58,9 @@ export function useMultipleOverlay(
           id,
           <OverlayController
             key={Date.now()}
-            ref={overlayRefs[index]}
+            ref={(ref) => {
+              overlayRefs.current[index] = ref;
+            }}
             overlayElement={overlayElement}
             onExit={() => {
               unmount(id);

--- a/src/hooks/useOverlay/useOverlay.tsx
+++ b/src/hooks/useOverlay/useOverlay.tsx
@@ -14,7 +14,7 @@ interface Options {
   exitOnUnmount?: boolean;
 }
 
-export function useOverlay({ exitOnUnmount = true }: Options = {}) {
+export const useOverlay = ({ exitOnUnmount = true }: Options = {}) => {
   const context = useContext(OverlayContext);
 
   if (context == null) {
@@ -60,4 +60,4 @@ export function useOverlay({ exitOnUnmount = true }: Options = {}) {
     }),
     [id, mount, unmount]
   );
-}
+};

--- a/src/hooks/useOverlay/useOverlay.tsx
+++ b/src/hooks/useOverlay/useOverlay.tsx
@@ -1,0 +1,63 @@
+// 참고: https://github.com/toss/slash/tree/main/packages/react/use-overlay
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  OverlayController,
+  OverlayControlRef,
+} from "@/hooks/useOverlay/OverlayController";
+import { OverlayContext } from "@/hooks/useOverlay/OverlayProvider";
+import { CreateOverlayElement } from "@/hooks/useOverlay/types";
+
+let elementId = 1;
+
+interface Options {
+  exitOnUnmount?: boolean;
+}
+
+export function useOverlay({ exitOnUnmount = true }: Options = {}) {
+  const context = useContext(OverlayContext);
+
+  if (context == null) {
+    throw new Error("useOverlay is only available within OverlayProvider.");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { mount, unmount } = context;
+  const [id] = useState(() => String(elementId++));
+
+  const overlayRef = useRef<OverlayControlRef | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (exitOnUnmount) {
+        unmount(id);
+      }
+    };
+  }, [exitOnUnmount, id, unmount]);
+
+  return useMemo(
+    () => ({
+      open: (overlayElement: CreateOverlayElement) => {
+        mount(
+          id,
+          <OverlayController
+            // NOTE: state should be reset every time we open an overlay
+            key={Date.now()}
+            ref={overlayRef}
+            overlayElement={overlayElement}
+            onExit={() => {
+              unmount(id);
+            }}
+          />
+        );
+      },
+      close: () => {
+        overlayRef.current?.close();
+      },
+      exit: () => {
+        unmount(id);
+      },
+    }),
+    [id, mount, unmount]
+  );
+}


### PR DESCRIPTION
## 개요
### 별도의 overlay로 분리하기
한 컴포넌트 내에서 쓰이는 여러 overlay에 대해 각기 구분을 해줘야했습니다.
왜냐하면 하나의 `const overlay = useOverlay();` 에 대해서 한 개의 컴포넌트만 담당하기 때문이죠. 즉 2개의 모달을 동시에 하나의 overlay로 열고자하면 다른 모달 하나가 열리지 않는 문제가 발생했습니다.
이런 문제를 방지하고자 컴포넌트 내에서 쓰이는 여러 overlay에 대해 별도로 분리하고자 했습니다.


### useMultipleOverlay
useOverlay 만으로 해당 작업을 수행하려고 보니 여러 솔루션들이 다 각기 아쉬운 부분이 있었습니다.

**방법 1**
단순하게 overlay 개수만큼 선언하고 뒤에 숫자 붙이기

const overlay = useOverlay();
const overlay1 = useOverlay();
const overlay2 = useOverlay();
const overlay3 = useOverlay();
…

useOverlay로 선언하는 부분이 overlay 개수만큼 길어지는 문제가 발생했습니다.

**방법 2**
각 overlay에 적절한 변수명을 짓기

const productListUpdateOverlay = useOverlay();
const ProductRestoreOverlay = useOverlay();
…

마찬가지로 overlay 개수만큼 길어지고, 변수명 짓기도 까다로웠습니다. (일반적인 버튼마다 명확한 이름을 짓기가 쉽지 않음)

**방법 3**
각 레이어별로 공통 overlay를 쓰기

overlay를 무조건 각기 써야하는 건 아니고, 중첩되는 레이어만 잘 파악한다면 공통으로 써도 된다는 점을 이용해서 해당 방법을 고안했으나 개발자들이 overlay를 쓸 때마다 레이어를 신경 써야한다는 점이 까다롭다고 판단했습니다.

**방법 4**
confirmOverlay, dialogOverlay 등 역할별로 나누기

해당 역할에도 중첩될 수 있기 때문에 const confirmOverlay1 = useOverlay(); … 결국 뒤에 숫자가 붙을 것이라 판단했습니다.

### 결론 - **방법 5**
useMultipleOverlay 훅을 직접 만들어서 사용

이렇게 될 시 선언부가 한 줄로 극단적으로 줄어듭니다.
```
const overlays = useMultipleOverlay(5); // 사용할 overlay 개수만큼 prop으로 넣어줌
```

이를 사용해서 overlay를 열고자할 때도 배열 순서대로 넣어주면 됩니다.
```
overlays[0].open(...)

overlays[1].open(...)
```
위의 배열 순서가 큰 의미가 있는 것도 아니기 때문에 쉽게 추가 및 삭제 가능하고 순서가 엉켜도 됩니다.

위의 결론을 통해서 useMultipleOverlay 훅을 직접 구현했고, 그러면서 useOverlay 훅 또한 기존 라이브러리 사용에서 커스텀 훅으로 직접 구현했습니다.


## 변경 사항
- @toss/use-overlay 대신 커스텀 hook 구현 (toss url은 hook 내에서 제공)
- useMultipleOverlay 구현 및 적용
- FolderActionModal 닫힘 로직 수정

## To Reviewers
e89721d 커밋에서 useOverlay 관련 코드는 대부분 [slash](https://github.com/toss/slash/tree/main/packages/react/use-overlay)의 코드입니다. 일부 수정만이 들어갔고, useMultipleOverlay만 직접 구현했습니다.


### TODO
ProductDetailModal과 ProductEditModal 상호작용 개선