### PR TITLE
ProductDetail, ProductEdit 모달 상호작용 로직 변경 #301

### DIFF
--- a/src/components/manager/product/ProductBoard.tsx
+++ b/src/components/manager/product/ProductBoard.tsx
@@ -244,6 +244,7 @@ const ProductBoard = ({
         folderList={productFolderList}
         productList={filteredProductList}
         setSelectedProductList={setSelectedProductList}
+        updateProductList={handleProductListUpdate}
       />
     </StyledProductBoard>
   );

--- a/src/components/manager/product/ProductDetailModal.int.test.tsx
+++ b/src/components/manager/product/ProductDetailModal.int.test.tsx
@@ -21,7 +21,8 @@ describe("ProductDetailModal", () => {
       <OverlayProvider>
         <ProductDetailModal
           overlayControl={control}
-          modalProductData={modalProductData}
+          product={modalProductData}
+          updateProductList={jest.fn()}
         />
       </OverlayProvider>
     );
@@ -46,7 +47,8 @@ describe("ProductDetailModal", () => {
       <OverlayProvider>
         <ProductDetailModal
           overlayControl={control}
-          modalProductData={modalProductData}
+          product={modalProductData}
+          updateProductList={jest.fn()}
         />
       </OverlayProvider>
     );

--- a/src/components/manager/product/ProductDetailModal.tsx
+++ b/src/components/manager/product/ProductDetailModal.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
+import { useState } from "react";
 
 import ImageWithFallback from "@/components/common/ImageWithFallback";
 import { StyledModal } from "@/components/manager/DashboardItems";
@@ -60,13 +61,16 @@ const StyledDetailModalContainer = styled.div`
 
 const ProductDetailModal = ({
   overlayControl,
-  modalProductData,
+  product,
+  updateProductList,
 }: {
   overlayControl: OverlayControl;
-  modalProductData: Product;
+  product: Product;
+  updateProductList: () => Promise<void>;
 }) => {
+  const [editedProduct, setEditedProduct] = useState<Product | null>(null);
   const { productId, image, composition, weightGPerM2, widthInch, colors } =
-    modalProductData;
+    editedProduct ? editedProduct : product;
   const overlay = useOverlay();
 
   const rows = colors.map(({ colorName, colorId }) => {
@@ -119,10 +123,13 @@ const ProductDetailModal = ({
               overlay.open((control) => (
                 <ProductEditModal
                   overlayControl={control}
-                  product={modalProductData}
+                  product={product}
+                  onProductUpdate={(p) => {
+                    setEditedProduct(p);
+                    void updateProductList();
+                  }}
                 />
               ));
-              overlayControl.close();
             }}
             data-testid={"product-detail-open-edit-modal-button"}
           >

--- a/src/components/manager/product/ProductEditModal.tsx
+++ b/src/components/manager/product/ProductEditModal.tsx
@@ -16,18 +16,19 @@ import {
   productEditionInitialValues,
   productEditionSchema,
 } from "@/components/manager/product/const";
-import ProductDetailModal from "@/components/manager/product/ProductDetailModal";
 import { OverlayControl, Product } from "@/const";
 import { useMultipleOverlay } from "@/hooks/useOverlay";
 
 const ProductEditModal = ({
   overlayControl,
   product,
+  onProductUpdate,
 }: {
   overlayControl: OverlayControl;
   product: Product;
+  onProductUpdate: (updatedProduct: Product) => void | Promise<void>;
 }) => {
-  const overlays = useMultipleOverlay(3);
+  const overlays = useMultipleOverlay(2);
   const formik = useFormik({
     initialValues: productEditionInitialValues,
     validateOnMount: true,
@@ -59,10 +60,8 @@ const ProductEditModal = ({
 
       try {
         const res = await putProduct(formData, product.productId);
-        overlays[0].open((control) => (
-          <ProductDetailModal overlayControl={control} modalProductData={res} />
-        ));
-        overlayControl.close();
+        await onProductUpdate(res);
+        overlayControl.exit();
       } catch (e) {
         overlays[1].open((control) => (
           <MessageDialog overlayControl={control} messageList={[e.message]} />
@@ -187,19 +186,7 @@ const ProductEditModal = ({
           >
             Confirm
           </Button>
-          <Button
-            onClick={() => {
-              overlays[2].open((control) => (
-                <ProductDetailModal
-                  overlayControl={control}
-                  modalProductData={product}
-                />
-              ));
-              overlayControl.close();
-            }}
-          >
-            Cancel
-          </Button>
+          <Button onClick={overlayControl.exit}>Cancel</Button>
         </StyledFlexDiv>
       </ProductAddModal>
     </StyledModal>

--- a/src/components/manager/product/ProductTable.test.tsx
+++ b/src/components/manager/product/ProductTable.test.tsx
@@ -25,6 +25,7 @@ describe("ProductTable", () => {
           folderList={folderList}
           productList={productList}
           setSelectedProductList={mockSetSelectedProductList}
+          updateProductList={jest.fn()}
         />
       </OverlayProvider>
     );
@@ -47,6 +48,7 @@ describe("ProductTable", () => {
           folderList={folderList}
           productList={productList}
           setSelectedProductList={mockSetSelectedProductList}
+          updateProductList={jest.fn()}
         />
       </OverlayProvider>
     );

--- a/src/components/manager/product/ProductTable.tsx
+++ b/src/components/manager/product/ProductTable.tsx
@@ -38,11 +38,13 @@ const ProductTable = ({
   folderList,
   productList,
   setSelectedProductList,
+  updateProductList,
 }: {
   folder: Folder;
   folderList: Folder[];
   productList: Product[];
   setSelectedProductList: Dispatch<SetStateAction<string[]>>;
+  updateProductList: () => Promise<void>;
 }) => {
   const tableRows = handleProductListForTable(productList, folderList);
   const overlay = useOverlay();
@@ -68,7 +70,8 @@ const ProductTable = ({
             overlay.open((control) => (
               <ProductDetailModal
                 overlayControl={control}
-                modalProductData={cell.row.__product__}
+                product={cell.row.__product__}
+                updateProductList={updateProductList}
               />
             ));
           }


### PR DESCRIPTION
## 개요
기존에는 ProductDetail 모달에서 ProductEdit 모달을 열고, ProductEdit 모달에서도 ProductDetail 모달을 여는 순환 구조였습니다.
이 방식은 useOverlay로 열었을 때, 이전 컴포넌트를 close를 하더라도 메모리에 계속 남아있는 문제가 발생했습니다.

이를 ProductEdit은 ProductDetail 모달 위의 레이어에서 보이도록 하고, 데이터 갱신 관련해선 onProductUpdate 핸들러를 통해서 직접 DetailModal의 값을 변경시켜줌과 동시에 handleProductUpdate를 통해서 Table을 갱신하도록 처리했습니다.

## 변경 사항
- ProductDetailModal, ProductEditModal 순환 구조 제거

## To Reviewers
