### PR TITLE
weChatId 유효성 검사 수정 #309

### DIFF
--- a/src/components/user/userSubmission/UserBasicInfo.tsx
+++ b/src/components/user/userSubmission/UserBasicInfo.tsx
@@ -41,12 +41,7 @@ const UserBasicInfo = ({ formik }: { formik: FormikProps<UserInfo> }) => {
         formik={formik}
       />
       {formik.values.countryCode.label === "China" && (
-        <UserInput
-          label="WeChat ID"
-          name="weChatId"
-          required={true}
-          formik={formik}
-        />
+        <UserInput label="WeChat ID" name="weChatId" formik={formik} />
       )}
       <UserInput
         label={t("Email")}

--- a/src/components/user/userSubmission/validation.ts
+++ b/src/components/user/userSubmission/validation.ts
@@ -36,10 +36,7 @@ export const userInfoValidationSchema = Yup.object().shape({
       phone: Yup.string().required(REQUIRED_TEXT),
     })
     .required(REQUIRED_TEXT),
-  weChatId: Yup.string().when("countryCode.label", {
-    is: "China",
-    then: () => Yup.string().required(REQUIRED_TEXT),
-  }),
+  weChatId: Yup.string().max(30, MAX_TEXT["30"]),
   phoneNumber: Yup.string()
     .matches(/^[0-9]+$/, NUMBER_TEXT)
     .required(REQUIRED_TEXT)


### PR DESCRIPTION
<!-- 제목 뒤에 # 이슈번호 붙여주세요. -->

## 개요

전시회 개최 중 클라이언트에게서 weChatId 입력이 필수가 아니게 해달라는 추가 요청사항을 받았습니다.
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## 변경 사항

- 유효성 검사에서 weChatId가 필수가 아니고, 최대 30자까지 입력 가능하도록 수정했습니다.

## To Reviewers
