### PR TITLE
모든 언어별 폰트를 클라이언트가 다운 받던 현상 개선 #322

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,26 +1,14 @@
 import { dir } from "i18next";
 import { Metadata } from "next";
-import { Noto_Sans, Noto_Sans_JP, Noto_Sans_SC } from "next/font/google";
 import { ReactNode } from "react";
 
 import { META } from "@/components/const";
+import { Language } from "@/const";
 import { i18nConfig } from "@/i18n";
 
 export function generateStaticParams() {
   return i18nConfig.locales.map((locale) => ({ locale }));
 }
-
-const NotoSans = Noto_Sans({
-  subsets: ["latin"],
-});
-
-const NotoSansSc = Noto_Sans_SC({
-  subsets: ["latin"],
-});
-
-const NotoSansJp = Noto_Sans_JP({
-  subsets: ["latin"],
-});
 
 const { title, description, url, ogImage, siteName, type } = META;
 
@@ -55,29 +43,18 @@ export const metadata: Metadata = {
   },
 };
 
-const getFontByLocale = (locale) => {
-  switch (locale) {
-    case "zh":
-      return NotoSansSc.className;
-    case "ja":
-      return NotoSansJp.className;
-    default:
-      return NotoSans.className;
-  }
-};
-
 export default function RootLayout({
   children,
   params: { locale },
 }: {
   children: ReactNode;
   params: {
-    locale: string;
+    locale: Language;
   };
 }) {
   return (
     <html lang={locale} dir={dir(locale)}>
-      <body className={getFontByLocale(locale)}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/[locale]/manager/layout.tsx
+++ b/src/app/[locale]/manager/layout.tsx
@@ -1,13 +1,9 @@
-import { Noto_Sans } from "next/font/google";
+import { ReactNode } from "react";
 
-const NotoSans = Noto_Sans({
-  subsets: ["latin"],
-});
-
-export default function RootLayout({ children }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang={"ko"}>
-      <body className={NotoSans.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/[locale]/manager/page.tsx
+++ b/src/app/[locale]/manager/page.tsx
@@ -3,6 +3,7 @@
 import { NextPage } from "next";
 
 import CommonProvider from "@/components/common/CommonProvider";
+import NotoSans from "@/components/fonts/NotoSans";
 import ManagerPage from "@/components/pages/ManagerPage";
 import { Language } from "@/const";
 
@@ -15,6 +16,7 @@ interface ManagerProps {
 const Manager: NextPage<ManagerProps> = ({ params: { locale } }) => {
   return (
     <CommonProvider locale={locale}>
+      <NotoSans />
       <ManagerPage />
     </CommonProvider>
   );

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { NextPage } from "next";
+import dynamic from "next/dynamic";
 import { RecoilRoot } from "recoil";
 
 import CommonProvider from "@/components/common/CommonProvider";
@@ -14,9 +15,23 @@ interface HomeProps {
   };
 }
 
+const getFontComponent = (locale: Language) => {
+  switch (locale) {
+    case "zh":
+      return dynamic(() => import("@/components/fonts/NotoSansSc"));
+    case "ja":
+      return dynamic(() => import("@/components/fonts/NotoSansJp"));
+    default:
+      return dynamic(() => import("@/components/fonts/NotoSans"));
+  }
+};
+
 const Home: NextPage<HomeProps> = ({ params: { locale } }) => {
+  const Font = getFontComponent(locale);
+
   return (
     <CommonProvider locale={locale}>
+      <Font />
       <RecoilRoot>
         <MessageSnackBar />
         <MainPage />

--- a/src/components/fonts/NotoSans.tsx
+++ b/src/components/fonts/NotoSans.tsx
@@ -1,0 +1,18 @@
+import { Noto_Sans } from "next/font/google";
+import { useEffect } from "react";
+
+const notoSans = Noto_Sans({
+  subsets: ["latin"],
+});
+
+export default function NotoSans() {
+  useEffect(() => {
+    document.body.classList.add(notoSans.className);
+
+    return () => {
+      document.body.classList.remove(notoSans.className);
+    };
+  }, []);
+
+  return <></>;
+}

--- a/src/components/fonts/NotoSansJp.tsx
+++ b/src/components/fonts/NotoSansJp.tsx
@@ -1,0 +1,18 @@
+import { Noto_Sans_JP } from "next/font/google";
+import { useEffect } from "react";
+
+const notoSansJp = Noto_Sans_JP({
+  subsets: ["latin"],
+});
+
+export default function NotoSansJp() {
+  useEffect(() => {
+    document.body.classList.add(notoSansJp.className);
+
+    return () => {
+      document.body.classList.remove(notoSansJp.className);
+    };
+  }, []);
+
+  return <></>;
+}

--- a/src/components/fonts/NotoSansSc.tsx
+++ b/src/components/fonts/NotoSansSc.tsx
@@ -1,0 +1,18 @@
+import { Noto_Sans_SC } from "next/font/google";
+import { useEffect } from "react";
+
+const notoSansSc = Noto_Sans_SC({
+  subsets: ["latin"],
+});
+
+export default function NotoSansSc() {
+  useEffect(() => {
+    document.body.classList.add(notoSansSc.className);
+
+    return () => {
+      document.body.classList.remove(notoSansSc.className);
+    };
+  }, []);
+
+  return <></>;
+}


### PR DESCRIPTION
<!-- 제목 뒤에 # 이슈번호 붙여주세요. -->

## 개요

기존에는 클라이언트에서 모든 언어별 폰트에 대해서 전부 다운을 받아왔습니다.
<img width="653" alt="image-2" src="https://github.com/user-attachments/assets/d3de0ae0-1dbb-47d5-811f-0759b3545662">

이 이슈에 대해서 [논의한 글](https://github.com/vercel/next.js/discussions/40345) 등을 읽어본 결과, 해결책으로 client 단에서 들어오는 특정 언어에 대해 dynamic import 처리를 결정했습니다.

이는 FOUT을 유발하지만 저희 애플리케이션은 Splash screen이 있기 때문에 괜찮다고 판단했습니다.

이를 처리하기 위해서 server 단("use client" 바깥)에서 처리되고 있던 폰트를 client단에서 처리하도록 변경했습니다.
하지만 layout.tsx에는 body 태그가 있어야하기 때문에, 각 폰트 컴포넌트 내부에서 useEffect를 통해 직접 body 태그의 classname을 변경해주는 식으로 처리했습니다.


<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## 변경 사항
- 폰트 로딩 로직을 서버 사이드에서 클라이언트 사이드로 이동
- dynamic import를 사용하여 필요한 폰트만 로드하도록 변경

## To Reviewers
