### PR TITLE
TranslationsProvider 개선 #326

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "formik": "^2.4.5",
         "franc": "^6.2.0",
         "i18next": "^23.11.3",
-        "i18next-resources-to-backend": "^1.2.1",
         "jsqr": "^1.4.0",
         "jszip": "^3.10.1",
         "next": "14.1.4",
@@ -9735,14 +9734,6 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
-      }
-    },
-    "node_modules/i18next-resources-to-backend": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-resources-to-backend/-/i18next-resources-to-backend-1.2.1.tgz",
-      "integrity": "sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "formik": "^2.4.5",
     "franc": "^6.2.0",
     "i18next": "^23.11.3",
-    "i18next-resources-to-backend": "^1.2.1",
     "jsqr": "^1.4.0",
     "jszip": "^3.10.1",
     "next": "14.1.4",

--- a/src/i18n/TranslationsProvider.tsx
+++ b/src/i18n/TranslationsProvider.tsx
@@ -1,21 +1,32 @@
 "use client";
 
-import { createInstance } from "i18next";
-import { ReactNode } from "react";
+import { createInstance, i18n } from "i18next";
+import { ReactNode, useEffect, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 
 import { Language } from "@/const";
 import { initTranslations } from "@/i18n";
 
-const TranslationsProvider = async ({
+const TranslationsProvider = ({
   children,
   locale,
 }: {
   children: ReactNode;
   locale: Language;
 }) => {
-  const i18n = createInstance();
-  await initTranslations(locale, ["common"], i18n);
+  const [i18n, setI18n] = useState<i18n | null>(null);
+
+  useEffect(() => {
+    const initI18n = async () => {
+      const i18nInstance = createInstance();
+      await initTranslations(locale, ["common"], i18nInstance);
+      setI18n(i18nInstance);
+    };
+
+    void initI18n();
+  }, [locale]);
+
+  if (!i18n) return <></>;
 
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 };

--- a/src/i18n/initTranslations.ts
+++ b/src/i18n/initTranslations.ts
@@ -1,9 +1,19 @@
 import { i18n } from "i18next";
-import resourcesToBackend from "i18next-resources-to-backend";
 import { initReactI18next } from "react-i18next/initReactI18next";
 
 import { Language } from "@/const";
 import { i18nConfig } from "@/i18n";
+import enCommon from "@/locales/en/common.json";
+import jaCommon from "@/locales/ja/common.json";
+import koCommon from "@/locales/ko/common.json";
+import zhCommon from "@/locales/zh/common.json";
+
+const resourceList = {
+  en: { common: enCommon },
+  ja: { common: jaCommon },
+  ko: { common: koCommon },
+  zh: { common: zhCommon },
+};
 
 const initTranslations = async (
   locale: Language,
@@ -11,14 +21,8 @@ const initTranslations = async (
   i18nInstance: i18n
 ) => {
   i18nInstance.use(initReactI18next);
-  i18nInstance.use(
-    resourcesToBackend(
-      (language: Language, namespace: string) =>
-        import(`@/locales/${language}/${namespace}.json`)
-    )
-  );
-
   await i18nInstance.init({
+    resources: resourceList,
     lng: locale,
     supportedLngs: i18nConfig.locales,
     defaultNS: namespaces[0],


### PR DESCRIPTION
<!-- 제목 뒤에 # 이슈번호 붙여주세요. -->

## 개요

TranslationsProvider는 클라이언트 컴포넌트이기 때문에 async를 제거했습니다.
또한 i18n의 init에 대해서 await에 대해 useEffect로 적절히 처리해주었습니다.
i18n 인스턴스가 없을 시 Fragment를 반환하기 때문에 loading time을 직접 재보았으나 기존과 유의미한 차이는 없었습니다.

initTranslations의 resourcesToBackend 대신 직접 json 파일을 resource로 넣도록 처리했습니다.
```js
const resource = {
    [locale]: resourceList[locale],
};
```
위의 코드처럼 특정 locale에 대한 파일만 resource로 전달하는 방법도 고안했으나, 매니저 페이지에선 PDF를 위해서 다국어 json이 필요하고, 어차피 빌드 시 파일 크기에 유의미한 차이가 없기에 해당 방법으로 처리하지 않았습니다.

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## 변경 사항
- TranslationsProvider, initTranslations 개선
- i18next-resources-to-backend 패키지 제거

## To Reviewers
